### PR TITLE
refactor!: error propagation system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Starting from Rust port of the project, all changes will be put into this file.
 
+## Unreleased
+### Breaking Changes
+- Create a new `Error` type for all sources, this replace `anyhow` error type.
+This should give more consistent error handling across all sources.
+
+### Build
+- Update `reqwest`, and `serde-*`
+- Remove `anyhow` as direct dependency
+
 ## [0.6.1] (2024-08-13)
 ### Changes
 - Fix issue with manual merging `Ctrl+C` handling not working properly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,6 +2483,7 @@ dependencies = [
  "supports-hyperlinks",
  "tokio",
  "tosho-amap",
+ "tosho-common",
  "tosho-kmkc",
  "tosho-macros",
  "tosho-mplus",
@@ -2511,6 +2512,17 @@ dependencies = [
  "time",
  "tokio",
  "tosho-macros",
+]
+
+[[package]]
+name = "tosho-common"
+version = "0.1.0"
+dependencies = [
+ "image",
+ "prost",
+ "reqwest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2563,7 +2575,6 @@ dependencies = [
 name = "tosho-musq"
 version = "0.5.0"
 dependencies = [
- "anyhow",
  "base64",
  "chrono",
  "futures-util",
@@ -2571,6 +2582,7 @@ dependencies = [
  "reqwest",
  "serde",
  "tokio",
+ "tosho-common",
  "tosho-macros",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,18 +2060,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2080,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ rust-version = "1.80.0"
 
 [workspace.dependencies]
 tokio = { version = "1.39.3", features = ["full"] }
-reqwest = { version = "0.12.5", features = ["rustls-tls", "socks", "stream"] }
-serde = { version = "1.0.208", features = ["derive"] }
-serde_json = "1.0.125"
+reqwest = { version = "0.12.7", features = ["rustls-tls", "socks", "stream"] }
+serde = { version = "1.0.209", features = ["derive"] }
+serde_json = "1.0.127"
 prost = "0.13.1"
 anyhow = "1"
 base64 = "0.22.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "tosho_rbean",
     "tosho_mplus",
     "tosho_macros",
+    "tosho_common",
 ]
 
 [workspace.package]

--- a/tosho/Cargo.toml
+++ b/tosho/Cargo.toml
@@ -15,6 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 # Sources deps
+tosho-common = { path = "../tosho_common", version = "=0.1.0" }
 tosho-musq = { path = "../tosho_musq", version = "=0.5.0" }
 tosho-kmkc = { path = "../tosho_kmkc", version = "=0.5.0" }
 tosho-amap = { path = "../tosho_amap", version = "=0.5.0" }

--- a/tosho/src/impl/musq/common.rs
+++ b/tosho/src/impl/musq/common.rs
@@ -1,5 +1,6 @@
 use color_print::cformat;
 use num_format::{Locale, ToFormattedString};
+use tosho_common::{ToshoError, ToshoResult};
 use tosho_musq::{
     constants::BASE_HOST,
     proto::{BadgeManga, ChapterV2, LabelBadgeManga, MangaDetailV2, MangaResultNode, UserPoint},
@@ -64,7 +65,7 @@ pub(super) async fn common_purchase_select(
     no_input: bool,
     console: &crate::term::Terminal,
 ) -> (
-    anyhow::Result<Vec<ChapterV2>>,
+    ToshoResult<Vec<ChapterV2>>,
     Option<MangaDetailV2>,
     Option<UserPoint>,
 ) {
@@ -161,7 +162,7 @@ pub(super) async fn common_purchase_select(
                 None => {
                     console.warn("Aborted");
                     (
-                        Err(anyhow::anyhow!("Aborted")),
+                        Err(ToshoError::new("Aborted by user")),
                         Some(result.clone()),
                         Some(user_bal),
                     )

--- a/tosho_common/Cargo.toml
+++ b/tosho_common/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tosho-common"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+keywords = ["api", "library"]
+description = "A common shared library used by tosho-* sources crates."
+readme = "./README.md"
+# Do not include tests in crates.io package
+exclude = [
+    "tests/*",
+]
+
+[dependencies]
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+prost.workspace = true
+image.workspace = true

--- a/tosho_common/README.md
+++ b/tosho_common/README.md
@@ -1,0 +1,9 @@
+# tosho-common
+
+A common shared library used by tosho-* sources crates.
+
+Not recommended to be used by other projects.
+
+## License
+
+This project is licensed with MIT License ([LICENSE](https://github.com/noaione/tosho-mango/blob/master/LICENSE) or http://opensource.org/licenses/MIT)

--- a/tosho_common/src/errors.rs
+++ b/tosho_common/src/errors.rs
@@ -1,0 +1,293 @@
+pub type ToshoResult<T> = Result<T, ToshoError>;
+
+/// All the common error types for the library
+#[derive(Debug)]
+pub enum ToshoError {
+    /// Error type that happens when making a request
+    RequestError(reqwest::Error),
+    /// Error type that happens when parsing the response from the API
+    ParseError(ToshoParseError),
+    /// Error type that happens when processing images
+    ImageError(ToshoImageError),
+    /// Error type that happens when doing any kind of IO operation (e.g. writing a file)
+    IOError(std::io::Error),
+    /// Other errors that doesn't fit the other categories
+    CommonError(String),
+}
+
+impl ToshoError {
+    /// Create a new instance of the error
+    ///
+    /// This will wrap the message into a [`ToshoError::CommonError`].
+    /// For other error types, use [`From`] implementations.
+    pub fn new(message: impl Into<String>) -> Self {
+        ToshoError::CommonError(message.into())
+    }
+}
+
+pub struct ToshoDetailedParseError {
+    inner: serde_json::Error,
+    status_code: reqwest::StatusCode,
+    headers: reqwest::header::HeaderMap,
+    url: reqwest::Url,
+    raw_text: String,
+}
+
+impl ToshoDetailedParseError {
+    /// Create a new instance of the error
+    pub fn new(
+        inner: serde_json::Error,
+        status_code: reqwest::StatusCode,
+        headers: reqwest::header::HeaderMap,
+        url: reqwest::Url,
+        raw_text: impl Into<String>,
+    ) -> Self {
+        Self {
+            inner,
+            status_code,
+            headers,
+            url,
+            raw_text: raw_text.into(),
+        }
+    }
+
+    /// Get the JSON excerpt from the raw text
+    fn get_json_excerpt(&self) -> String {
+        let row_line = self.inner.line() - 1;
+        let split_lines = self.raw_text.split('\n').collect::<Vec<&str>>();
+
+        let position = self.inner.column();
+        let start_idx = position.saturating_sub(25);
+        let end_idx = position.saturating_add(25);
+
+        // Bound the start and end index
+        let start_idx = start_idx.max(0);
+        let end_idx = end_idx.min(split_lines[row_line].len());
+
+        split_lines[row_line][start_idx..end_idx].to_string()
+    }
+}
+
+impl std::fmt::Display for ToshoDetailedParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Failed to parse response from {} with status code {}: {}\n\nHeaders: {:?}\nExcerpt: {}",
+            self.url, self.status_code, self.inner, self.headers, self.get_json_excerpt()
+        )
+    }
+}
+
+impl std::fmt::Debug for ToshoDetailedParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // make struct, do not include raw_text
+        f.debug_struct("ToshoDetailedParseError")
+            .field("inner", &self.inner)
+            .field("status_code", &self.status_code)
+            .field("headers", &self.headers)
+            .field("url", &self.url)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct ToshoDetailedFailableError {
+    message: String,
+    inner: Box<ToshoError>,
+}
+
+impl ToshoDetailedFailableError {
+    pub fn new(message: impl Into<String>, inner: ToshoError) -> Self {
+        Self {
+            message: message.into(),
+            inner: Box::new(inner),
+        }
+    }
+}
+
+impl std::fmt::Display for ToshoDetailedFailableError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.message, self.inner)
+    }
+}
+
+/// Error type that happens when parsing the response from the API
+#[derive(Debug)]
+pub enum ToshoParseError {
+    /// Failed to parse the response as JSON
+    SerdeError(serde_json::Error),
+    /// A more detailed error when parsing the response as JSON
+    SerdeDetailedError(ToshoDetailedParseError),
+    SerdeFailableError(ToshoDetailedFailableError),
+    /// Failed to parse the response as Protobuf
+    ProstError(prost::DecodeError),
+    /// Response is empty
+    EmptyResponse,
+    /// Invalid status code
+    InvalidStatusCode(reqwest::StatusCode),
+}
+
+/// Error type that happens when processing images
+#[derive(Debug)]
+pub enum ToshoImageError {
+    /// Number conversion error
+    ConversionError(std::num::ParseIntError),
+    /// Image processing error
+    ImageError(ToshoDetailedImageError),
+    /// Image decoding error
+    ReadError(String),
+    /// Image encoding error
+    WriteError(String),
+}
+
+/// Error type that happens when processing images
+#[derive(Debug)]
+pub struct ToshoDetailedImageError {
+    inner: image::ImageError,
+    description: String,
+}
+
+impl ToshoDetailedImageError {
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = description.into();
+        self
+    }
+}
+
+impl std::fmt::Display for ToshoDetailedImageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.description, self.inner)
+    }
+}
+
+impl From<ToshoDetailedParseError> for ToshoParseError {
+    fn from(value: ToshoDetailedParseError) -> Self {
+        ToshoParseError::SerdeDetailedError(value)
+    }
+}
+
+impl From<ToshoDetailedParseError> for ToshoError {
+    fn from(value: ToshoDetailedParseError) -> Self {
+        ToshoError::ParseError(ToshoParseError::SerdeDetailedError(value))
+    }
+}
+
+/// Error type that happens when authenticating
+#[derive(Debug)]
+pub enum ToshoAuthError {
+    /// Happens when the credentials are invalid
+    InvalidCredentials,
+    /// Happens when the session is invalid
+    InvalidSession,
+    /// Happens when tosho unable to get the session
+    UnknownSession,
+}
+
+impl From<reqwest::Error> for ToshoError {
+    fn from(value: reqwest::Error) -> Self {
+        ToshoError::RequestError(value)
+    }
+}
+
+impl From<serde_json::Error> for ToshoError {
+    fn from(value: serde_json::Error) -> Self {
+        ToshoError::ParseError(ToshoParseError::SerdeError(value))
+    }
+}
+
+impl From<prost::DecodeError> for ToshoError {
+    fn from(value: prost::DecodeError) -> Self {
+        ToshoError::ParseError(ToshoParseError::ProstError(value))
+    }
+}
+
+impl From<std::io::Error> for ToshoError {
+    fn from(value: std::io::Error) -> Self {
+        ToshoError::IOError(value)
+    }
+}
+
+impl From<image::ImageError> for ToshoError {
+    fn from(value: image::ImageError) -> Self {
+        // Determine error kind
+        match value {
+            image::ImageError::Decoding(hint) => {
+                let fmt_hint = match hint.format_hint() {
+                    image::error::ImageFormatHint::Exact(fmt) => fmt.to_mime_type().to_string(),
+                    image::error::ImageFormatHint::Name(name) => name,
+                    image::error::ImageFormatHint::PathExtension(ext) => format!("{:?}", ext),
+                    image::error::ImageFormatHint::Unknown => "Unknown".to_string(),
+                    _ => "Unknown Error Handled".to_string(),
+                };
+
+                ToshoError::ImageError(ToshoImageError::ReadError(fmt_hint))
+            }
+            image::ImageError::Encoding(hint) => {
+                let fmt_hint = match hint.format_hint() {
+                    image::error::ImageFormatHint::Exact(fmt) => fmt.to_mime_type().to_string(),
+                    image::error::ImageFormatHint::Name(name) => name,
+                    image::error::ImageFormatHint::PathExtension(ext) => format!("{:?}", ext),
+                    image::error::ImageFormatHint::Unknown => "Unknown".to_string(),
+                    _ => "Unknown Error Handled".to_string(),
+                };
+
+                ToshoError::ImageError(ToshoImageError::WriteError(fmt_hint))
+            }
+            image::ImageError::IoError(io_err) => ToshoError::IOError(io_err),
+            _ => ToshoError::ImageError(ToshoImageError::ImageError(ToshoDetailedImageError {
+                inner: value,
+                description: "Image processing error".to_string(),
+            })),
+        }
+    }
+}
+
+impl From<ToshoParseError> for ToshoError {
+    fn from(value: ToshoParseError) -> Self {
+        ToshoError::ParseError(value)
+    }
+}
+
+impl From<ToshoImageError> for ToshoError {
+    fn from(value: ToshoImageError) -> Self {
+        ToshoError::ImageError(value)
+    }
+}
+
+impl std::fmt::Display for ToshoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ToshoError::CommonError(msg) => write!(f, "{}", msg),
+            ToshoError::RequestError(e) => write!(f, "Request error: {}", e),
+            ToshoError::ParseError(e) => write!(f, "Parse error: {}", e),
+            ToshoError::ImageError(e) => write!(f, "Image error: {}", e),
+            ToshoError::IOError(e) => write!(f, "IO error: {}", e),
+        }
+    }
+}
+
+impl std::fmt::Display for ToshoParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ToshoParseError::SerdeError(e) => write!(f, "Serde error: {}", e),
+            ToshoParseError::SerdeDetailedError(e) => write!(f, "{}", e),
+            ToshoParseError::SerdeFailableError(e) => write!(f, "{}", e),
+            ToshoParseError::ProstError(e) => write!(f, "Failed to decode protobuf data: {}", e),
+            ToshoParseError::EmptyResponse => write!(f, "Empty response received"),
+            ToshoParseError::InvalidStatusCode(code) => write!(f, "Invalid status code: {}", code),
+        }
+    }
+}
+
+impl std::fmt::Display for ToshoImageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ToshoImageError::ConversionError(e) => {
+                write!(f, "An error occured while tyring to convert number: {}", e)
+            }
+            ToshoImageError::ImageError(e) => write!(f, "{}", e),
+            ToshoImageError::ReadError(e) => write!(f, "Failed to read image: {}", e),
+            ToshoImageError::WriteError(e) => write!(f, "Failed to write image: {}", e),
+        }
+    }
+}

--- a/tosho_common/src/lib.rs
+++ b/tosho_common/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod errors;
+pub mod parser;
+
+pub use errors::*;
+pub use parser::*;

--- a/tosho_common/src/parser.rs
+++ b/tosho_common/src/parser.rs
@@ -1,0 +1,75 @@
+use crate::{
+    ToshoDetailedFailableError, ToshoDetailedParseError, ToshoError, ToshoParseError, ToshoResult,
+};
+
+/// Trait for all responses that can be parsed.
+pub trait FailableResponse {
+    /// Raise an error if the response is not successful.
+    fn raise_for_status(&self) -> ToshoResult<()>;
+    fn format_error(&self) -> String;
+}
+
+/// Parse a JSON response.
+pub async fn parse_json_response<T>(response: reqwest::Response) -> ToshoResult<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let stat_code = response.status();
+    let headers = response.headers().clone();
+    let url = response.url().clone();
+    let raw_text = response.text().await?;
+    let json: T = serde_json::from_str(&raw_text)
+        .map_err(|e| ToshoDetailedParseError::new(e, stat_code, headers, url, raw_text))?;
+
+    Ok(json)
+}
+
+/// Parse a JSON response with two possible response types.
+///
+/// This function is useful when the API returns some kind of error response
+pub async fn parse_json_response_failable<T, E>(response: reqwest::Response) -> ToshoResult<T>
+where
+    T: serde::de::DeserializeOwned,
+    E: serde::de::DeserializeOwned + std::fmt::Debug + FailableResponse,
+{
+    let stat_code = response.status();
+    let headers = response.headers().clone();
+    let url = response.url().clone();
+    let raw_text = response.text().await?;
+    let status_resp: E = serde_json::from_str(&raw_text)
+        .map_err(|e| ToshoDetailedParseError::new(e, stat_code, headers, url, &raw_text))?;
+
+    match status_resp.raise_for_status() {
+        Ok(_) => {
+            let json: T = serde_json::from_str(&raw_text)?;
+            Ok(json)
+        }
+        // If the status response is an error, return the error
+        Err(e) => {
+            let error_message = status_resp.format_error();
+            let fail_error = ToshoDetailedFailableError::new(error_message, e);
+            Err(ToshoError::ParseError(ToshoParseError::SerdeFailableError(
+                fail_error,
+            )))
+        }
+    }
+}
+
+/// Parse a Protobuf response.
+pub async fn parse_protobuf_response<T>(response: reqwest::Response) -> ToshoResult<T>
+where
+    T: prost::Message + Clone + Default,
+{
+    if response.status().is_success() {
+        let bytes_data = response.bytes().await?;
+        let decoded = T::decode(&bytes_data[..])?;
+
+        Ok(decoded)
+    } else {
+        let status_code = response.status();
+
+        Err(ToshoError::ParseError(ToshoParseError::InvalidStatusCode(
+            status_code,
+        )))
+    }
+}

--- a/tosho_musq/Cargo.toml
+++ b/tosho_musq/Cargo.toml
@@ -21,10 +21,10 @@ exclude = [
 tokio.workspace = true
 serde.workspace = true
 prost.workspace = true
-anyhow.workspace = true
 base64.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
 futures-util.workspace = true
 
 tosho-macros = { path = "../tosho_macros", version = "0.3" }
+tosho-common = { path = "../tosho_common", version = "=0.1.0" }

--- a/tosho_musq/src/lib.rs
+++ b/tosho_musq/src/lib.rs
@@ -467,8 +467,7 @@ impl MUClient {
             .post(self.build_url("/manga/viewer_v2"))
             .form(&params)
             .send()
-            .await
-            .unwrap();
+            .await?;
 
         let viewer: ChapterViewerV2 = parse_protobuf_response(res).await?;
 
@@ -626,8 +625,7 @@ impl MUClient {
                 headers
             })
             .send()
-            .await
-            .unwrap();
+            .await?;
 
         // bail if not success
         if !res.status().is_success() {


### PR DESCRIPTION
Remove all instances of `anyhow` on all sources crates.
Also removed some "failable" `.unwrap()` and wrap it into `ToshoResult`

Closes #49 