### PR TITLE
refactor!: make all models and config fields private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ This should give more consistent error handling across all sources.
   - `Error` is the new error type that is used across all sources.
 - All sources: Make all fields private on models, you can now use getter function instead.
   - Example: `data.name` now become `data.name()`
-- `KM`, `RB`: Private config fields, please use the getter function and the *new* `new` function to create a new config.
+- `KM`, `RB`, `AM`: Privatize config fields
+  - Please use the getter function and the *new* `new` function to create a new config.
 
 ### Changes
 - `MU`: Proto changes for subscription in manga detail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This should give more consistent error handling across all sources.
   - `Error` is the new error type that is used across all sources.
 - All sources: Make all fields private on models, you can now use getter function instead.
   - Example: `data.name` now become `data.name()`
-- `KM`, `RB`, `AM`: Privatize config fields
+- `KM`, `RB`, `AM`, and `SJ/V`: Privatize config fields
   - Please use the getter function and the *new* `new` function to create a new config.
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This should give more consistent error handling across all sources.
   - `Error` is the new error type that is used across all sources.
 - All sources: Make all fields private on models, you can now use getter function instead.
   - Example: `data.name` now become `data.name()`
+  - For `KM`, use the *new* `new` function that will help create the config.
 
 ### Changes
 - `MU`: Proto changes for subscription in manga detail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This should give more consistent error handling across all sources.
   - `Error` is the new error type that is used across all sources.
 - All sources: Make all fields private on models, you can now use getter function instead.
   - Example: `data.name` now become `data.name()`
-  - For `KM`, use the *new* `new` function that will help create the config.
+- `KM`, `RB`: Private config fields, please use the getter function and the *new* `new` function to create a new config.
 
 ### Changes
 - `MU`: Proto changes for subscription in manga detail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This should give more consistent error handling across all sources.
 - All source: flush bytes stream on each loop iteration
 - `RB`: Possibly faster image decryption
 - All sources: Replace `String` or `&str` input on client with `impl Into<String>` instead
+- All sources: Add `Copy` to some `Copy`-able struct
 - Adjust exit code handling on CLI
 - Simplify progress bar handling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This should give more consistent error handling across all sources.
 - `KM`: Replace all `From` instance that is failable into `TryFrom` instead.
 - All sources: Client initialization now returns `Result<Self, Error>` format instead of `Self`.
   - `Error` is the new error type that is used across all sources.
+- All sources: Make all fields private on models, you can now use getter function instead.
+  - Example: `data.name` now become `data.name()`
 
 ### Changes
 - `MU`: Proto changes for subscription in manga detail
@@ -17,6 +19,7 @@ This should give more consistent error handling across all sources.
 - `MU`, `KM`, and `AM`: Cleanup `precalculate` command output a bit more
 - All source: flush bytes stream on each loop iteration
 - `RB`: Possibly faster image decryption
+- All sources: Replace `String` or `&str` input on client with `impl Into<String>` instead
 - Adjust exit code handling on CLI
 - Simplify progress bar handling
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,6 +2451,7 @@ dependencies = [
 name = "tosho-macros"
 version = "0.3.2"
 dependencies = [
+ "proc-macro2",
  "quote",
  "serde",
  "syn",

--- a/tosho/src/impl/amap/accounts.rs
+++ b/tosho/src/impl/amap/accounts.rs
@@ -65,9 +65,10 @@ pub async fn amap_account_login(
                         Ok(account) => {
                             let as_config = as_config
                                 .with_email(&email)
-                                .with_account_info(&account.info);
+                                .with_account_info(account.info());
 
-                            console.info(cformat!("Logged in as <m,s>{}</>", account.info.name));
+                            console
+                                .info(cformat!("Logged in as <m,s>{}</>", account.info().name()));
 
                             let final_config = match old_id {
                                 Some(old_id) => as_config.with_id(&old_id),
@@ -145,16 +146,16 @@ pub(crate) async fn amap_account_info(
         Ok(acc_resp) => {
             super::common::save_session_config(client, account);
 
-            let info = acc_resp.info;
+            let info = acc_resp.info();
 
             console.info(cformat!(
                 "Account info for <magenta,bold>{}</>:",
                 account.id
             ));
 
-            console.info(cformat!("  <s>ID</>: {}", info.id));
+            console.info(cformat!("  <s>ID</>: {}", info.id()));
             console.info(cformat!("  <s>Email</>: {}", account.email));
-            console.info(cformat!("  <s>Username</>: {}", info.name));
+            console.info(cformat!("  <s>Username</>: {}", info.name()));
 
             0
         }
@@ -181,12 +182,12 @@ pub(crate) async fn amap_account_balance(
         Ok(remainder) => {
             super::common::save_session_config(client, acc_info);
 
-            let balance = &remainder.info;
+            let balance = remainder.info();
 
             console.info("Your current point balance:");
             let total_ticket = balance.sum().to_formatted_string(&Locale::en);
-            let purchased = balance.purchased.to_formatted_string(&Locale::en);
-            let premium = balance.premium.to_formatted_string(&Locale::en);
+            let purchased = balance.purchased().to_formatted_string(&Locale::en);
+            let premium = balance.premium().to_formatted_string(&Locale::en);
             let total_point = balance.sum_point().to_formatted_string(&Locale::en);
 
             console.info(cformat!(

--- a/tosho/src/impl/amap/accounts.rs
+++ b/tosho/src/impl/amap/accounts.rs
@@ -51,7 +51,7 @@ pub async fn amap_account_login(
         Ok(session) => {
             console.info(cformat!(
                 "Authenticated as <m,s>{}</> ({})",
-                session.identifier,
+                session.identifier(),
                 email
             ));
 

--- a/tosho/src/impl/amap/common.rs
+++ b/tosho/src/impl/amap/common.rs
@@ -17,11 +17,7 @@ use crate::{
 
 impl From<super::config::Config> for tosho_amap::AMConfig {
     fn from(config: super::config::Config) -> Self {
-        tosho_amap::AMConfig {
-            token: config.token,
-            identifier: config.identifier,
-            session_v2: config.session,
-        }
+        tosho_amap::AMConfig::new(&config.token, &config.identifier, &config.session)
     }
 }
 

--- a/tosho/src/impl/amap/common.rs
+++ b/tosho/src/impl/amap/common.rs
@@ -90,8 +90,8 @@ pub(super) async fn common_purchase_select(
 
             let balance = &result.account;
             let total_ticket = balance.sum().to_formatted_string(&Locale::en);
-            let purchased = balance.purchased.to_formatted_string(&Locale::en);
-            let premium = balance.premium.to_formatted_string(&Locale::en);
+            let purchased = balance.purchased().to_formatted_string(&Locale::en);
+            let premium = balance.premium().to_formatted_string(&Locale::en);
             let total_point = balance.sum_point().to_formatted_string(&Locale::en);
 
             console.info("Your current point balance:");

--- a/tosho/src/impl/amap/config.rs
+++ b/tosho/src/impl/amap/config.rs
@@ -72,7 +72,7 @@ impl Config {
     /// Apply the account info response to the new config.
     pub fn with_account_info(self, info: &AccountUserInfo) -> Self {
         Self {
-            user_id: info.id,
+            user_id: info.id(),
             ..self
         }
     }

--- a/tosho/src/impl/amap/config.rs
+++ b/tosho/src/impl/amap/config.rs
@@ -47,9 +47,9 @@ impl From<AMConfig> for Config {
             id: new_uuid.clone(),
             email: format!("{}@amap.xyz", new_uuid),
             user_id: 0,
-            token: value.token,
-            identifier: value.identifier,
-            session: value.session_v2,
+            token: value.token().to_string(),
+            identifier: value.identifier().to_string(),
+            session: value.session_v2().to_string(),
             r#type: DeviceType::Android as i32,
         }
     }

--- a/tosho/src/impl/amap/download.rs
+++ b/tosho/src/impl/amap/download.rs
@@ -129,11 +129,11 @@ pub(crate) async fn amap_download(
             let mut ticket_purse = coin_purse.clone();
 
             if dl_config.no_premium {
-                ticket_purse.premium = 0;
+                ticket_purse.set_premium(0);
             }
 
             if dl_config.no_purchased {
-                ticket_purse.purchased = 0;
+                ticket_purse.set_purchased(0);
             }
 
             console.info(format!("Downloading {} chapters...", results.len()));
@@ -202,9 +202,9 @@ pub(crate) async fn amap_download(
                                 ));
                             } else {
                                 download_chapters.push(chapter);
-                                ticket_purse.bonus -= consume.bonus;
-                                ticket_purse.purchased -= consume.purchased;
-                                ticket_purse.premium -= consume.premium;
+                                ticket_purse.subtract_bonus(consume.bonus);
+                                ticket_purse.subtract_premium(consume.purchased);
+                                ticket_purse.subtract_premium(consume.premium);
                                 super::common::save_session_config(client, account);
                             }
                         }

--- a/tosho/src/impl/amap/download.rs
+++ b/tosho/src/impl/amap/download.rs
@@ -40,10 +40,11 @@ pub(crate) struct AMDownloadCliConfig {
 }
 
 fn create_chapters_info(manga_detail: &ComicInfo) -> MangaDetailDump {
-    let mut chapters: Vec<ChapterDetailDump> = vec![];
-    for chapter in manga_detail.episodes() {
-        chapters.push(ChapterDetailDump::from(chapter));
-    }
+    let chapters: Vec<ChapterDetailDump> = manga_detail
+        .episodes()
+        .iter()
+        .map(ChapterDetailDump::from)
+        .collect();
 
     let merged_authors = manga_detail
         .authors()

--- a/tosho/src/impl/amap/favorites.rs
+++ b/tosho/src/impl/amap/favorites.rs
@@ -18,17 +18,17 @@ pub(crate) async fn amap_my_favorites(
 
     match results {
         Ok(results) => {
-            if results.comics.is_empty() {
+            if results.comics().is_empty() {
                 console.error("You don't have any favorites.");
                 return 0;
             }
 
             console.info(cformat!(
                 "Your favorites list (<m,s>{}</> results):",
-                results.comics.len()
+                results.comics().len()
             ));
 
-            do_print_search_information(&results.comics, false, None);
+            do_print_search_information(results.comics(), false, None);
 
             0
         }

--- a/tosho/src/impl/amap/manga.rs
+++ b/tosho/src/impl/amap/manga.rs
@@ -19,17 +19,17 @@ pub(crate) async fn amap_search(
         Ok(results) => {
             super::common::save_session_config(client, acc_info);
 
-            if results.comics.is_empty() {
+            if results.comics().is_empty() {
                 console.warn("No results found");
                 return 1;
             }
 
             console.info(cformat!(
                 "Search results (<magenta,bold>{}</> results):",
-                results.comics.len()
+                results.comics().len()
             ));
 
-            do_print_search_information(&results.comics, false, None);
+            do_print_search_information(results.comics(), false, None);
 
             0
         }
@@ -41,10 +41,10 @@ pub(crate) async fn amap_search(
     }
 }
 
-fn format_tags(tags: Vec<ComicTagInfo>) -> String {
+fn format_tags(tags: &[ComicTagInfo]) -> String {
     let parsed_tags = tags
         .iter()
-        .map(|tag| cformat!("<p(244),reverse,bold>{}</>", tag.info.name))
+        .map(|tag| cformat!("<p(244),reverse,bold>{}</>", tag.info().name()))
         .collect::<Vec<String>>()
         .join(", ");
     parsed_tags
@@ -64,19 +64,19 @@ pub(crate) async fn amap_title_info(
 
     match results {
         Ok(results) => {
+            let info = results.info();
             let manga_url = format!("https://{}/manga/{}", &*BASE_HOST, title_id);
-            let linked = linkify!(&manga_url, &results.info.title);
+            let linked = linkify!(&manga_url, info.title());
 
             console.info(cformat!(
                 "Title information for <magenta,bold>{}</>:",
                 linked
             ));
 
-            let mapped_authors = results
-                .info
-                .authors
+            let mapped_authors = info
+                .authors()
                 .iter()
-                .map(|a| (a.info.kind.clone(), a.info.name.clone()))
+                .map(|a| (a.info().kind().to_string(), a.info().name().to_string()))
                 .collect::<Vec<(String, String)>>();
 
             console.info(cformat!("  <s>Authors</>:"));
@@ -84,32 +84,32 @@ pub(crate) async fn amap_title_info(
                 console.info(cformat!("    - <s>{}</>: {}", kind, name));
             }
 
-            console.info(cformat!("  <s>Tags</>: {}", format_tags(results.info.tags)));
-            console.info(cformat!(
-                "  <s>Status</>: {}",
-                results.info.status.to_name()
-            ));
+            console.info(cformat!("  <s>Tags</>: {}", format_tags(info.tags())));
+            console.info(cformat!("  <s>Status</>: {}", info.status().to_name()));
 
             console.info(cformat!("  <s>Summary</>"));
-            console.info(format!("   {}", results.info.description));
+            console.info(format!("   {}", info.description()));
 
             println!();
 
             console.info(cformat!(
                 "  <s>Chapters</>: {} chapters",
-                results.info.episodes.len()
+                info.episodes().len()
             ));
 
             if show_chapters {
-                for episode in results.info.episodes.iter() {
-                    let mut base_info =
-                        cformat!("    <s>{}</> ({})", episode.info.title, episode.info.id);
+                for episode in info.episodes().iter() {
+                    let mut base_info = cformat!(
+                        "    <s>{}</> ({})",
+                        episode.info().title(),
+                        episode.info().id()
+                    );
                     // add ticket price
-                    if episode.info.price > 0 {
+                    if episode.info().price() > 0 {
                         base_info =
-                            cformat!("{} [<r!,strong>{}</>T]", base_info, episode.info.price);
+                            cformat!("{} [<r!,strong>{}</>T]", base_info, episode.info().price());
 
-                        if episode.info.is_free_daily {
+                        if episode.info().is_free_daily() {
                             base_info = cformat!(
                                 "{} <g!,strong>[<rev>Free Daily</rev>]</g!,strong>",
                                 base_info
@@ -121,11 +121,11 @@ pub(crate) async fn amap_title_info(
                     }
                     console.info(&base_info);
                     if let Some(update_at) =
-                        unix_timestamp_to_string(episode.info.update_date as i64)
+                        unix_timestamp_to_string(episode.info().update_date() as i64)
                     {
                         console.info(cformat!("     Published at: <s>{}</>", update_at));
                     }
-                    if let Some(expiry_time) = episode.info.expiry_time {
+                    if let Some(expiry_time) = episode.info().expiry_time() {
                         if let Some(expiry_time) = unix_timestamp_to_string(expiry_time as i64) {
                             console.info(cformat!("      Expires at: <s>{}</>", expiry_time));
                         }
@@ -135,26 +135,22 @@ pub(crate) async fn amap_title_info(
 
             println!();
 
-            let prod_binding = results.info.productions.clone().replace("\r\n", "\n");
+            let prod_binding = info.productions().replace("\r\n", "\n");
             let prod_participants = prod_binding.split('\n');
             console.info(cformat!("  <s>Production Participants</>"));
             for prod in prod_participants {
                 console.info(format!("    - {}", prod));
             }
 
-            if let Some(free_daily) = results.info.free_daily {
-                let is_free_daily = if results.info.has_free_daily {
-                    "Yes"
-                } else {
-                    "No"
-                };
+            if let Some(free_daily) = info.free_daily() {
+                let is_free_daily = if info.has_free_daily() { "Yes" } else { "No" };
                 console.info(cformat!("  <s>Free Daily</>: {}", is_free_daily));
-                console.info(cformat!("    - <s>Term:</> {}", free_daily.term));
-                if let Some(next_reload) = unix_timestamp_to_string(free_daily.next as i64) {
+                console.info(cformat!("    - <s>Term:</> {}", free_daily.term()));
+                if let Some(next_reload) = unix_timestamp_to_string(free_daily.next() as i64) {
                     console.info(cformat!("    - <s>Next Reload:</> {}", next_reload));
                 }
             }
-            if let Some(rental_term) = results.info.rental_term {
+            if let Some(rental_term) = info.rental_term() {
                 console.info(cformat!("  <s>Rental Term</>: {}", rental_term));
             }
 

--- a/tosho/src/impl/amap/purchases.rs
+++ b/tosho/src/impl/amap/purchases.rs
@@ -34,16 +34,19 @@ pub(crate) async fn amap_purchase(
                     results.len()
                 ));
 
-                let consume =
-                    ComicPurchase::from_episode_and_comic(&comic, &chapter.info, &mut ticket_purse);
+                let consume = ComicPurchase::from_episode_and_comic(
+                    &comic,
+                    chapter.info(),
+                    &mut ticket_purse,
+                );
 
                 if consume.is_none() {
                     console.warn(cformat!(
                         "Unable to purchase chapter <magenta,bold>{}</> ({}), insufficient point balance!",
-                        chapter.info.title, chapter.info.id
+                        chapter.info().title(), chapter.info().id()
                     ));
                     failed_claimed.push((
-                        chapter.info.clone(),
+                        chapter.info().clone(),
                         "Insufficient point balance".to_string(),
                     ));
                     continue;
@@ -54,14 +57,14 @@ pub(crate) async fn amap_purchase(
 
                 match ch_view {
                     Ok(ch_view) => {
-                        if ch_view.info.pages.is_empty() {
+                        if ch_view.info().pages().is_empty() {
                             console.warn(cformat!(
                                 "Unable to purchase chapter <magenta,bold>{}</> ({}), no images found!",
-                                chapter.info.title,
-                                chapter.info.id
+                                chapter.info().title(),
+                                chapter.info().id()
                             ));
                             failed_claimed
-                                .push((chapter.info.clone(), "Failed when claiming".to_string()));
+                                .push((chapter.info().clone(), "Failed when claiming".to_string()));
                             continue;
                         }
 
@@ -75,11 +78,11 @@ pub(crate) async fn amap_purchase(
                     Err(err) => {
                         console.warn(cformat!(
                             "Unable to purchase chapter <magenta,bold>{}</> ({}), error: {}",
-                            chapter.info.title,
-                            chapter.info.id,
+                            chapter.info().title(),
+                            chapter.info().id(),
                             err
                         ));
-                        failed_claimed.push((chapter.info.clone(), format!("Error: {}", err)));
+                        failed_claimed.push((chapter.info().clone(), format!("Error: {}", err)));
                         continue;
                     }
                 }
@@ -97,8 +100,8 @@ pub(crate) async fn amap_purchase(
                 for (chapter, reason) in failed_claimed {
                     console.warn(cformat!(
                         "  - <bold>{}</> (ID: {}): <red,bold>{}</>",
-                        chapter.title,
-                        chapter.id,
+                        chapter.title(),
+                        chapter.id(),
                         reason
                     ));
                 }
@@ -126,7 +129,7 @@ pub(crate) async fn amap_purchase_precalculate(
             }
 
             console.info("Calculating chapters cost...");
-            let price_ticket: u64 = results.iter().map(|c| c.info.price).sum();
+            let price_ticket: u64 = results.iter().map(|c| c.info().price()).sum();
 
             let price_ticket_fmt = price_ticket.to_formatted_string(&Locale::en);
             let ch_count = results.len().to_formatted_string(&Locale::en);

--- a/tosho/src/impl/amap/rankings.rs
+++ b/tosho/src/impl/amap/rankings.rs
@@ -20,39 +20,39 @@ pub(crate) async fn amap_discovery(
             super::common::save_session_config(client, acc_info);
 
             // updated
-            for updated in results.updated.iter() {
-                console.info(format!("{}:", updated.header.title));
-                do_print_search_information(&updated.comics, false, None);
+            for updated in results.updated().iter() {
+                console.info(format!("{}:", updated.header().title()));
+                do_print_search_information(updated.comics(), false, None);
                 println!();
             }
 
             // free campaigns
-            if !results.free_campaigns.is_empty() {
+            if !results.free_campaigns().is_empty() {
                 console.info("Free Campaigns:");
             }
-            for campaign in results.free_campaigns.iter() {
-                console.info(format!("  {}:", campaign.header.title));
-                do_print_search_information(&campaign.comics, false, Some(4));
+            for campaign in results.free_campaigns().iter() {
+                console.info(format!("  {}:", campaign.header().title()));
+                do_print_search_information(campaign.comics(), false, Some(4));
                 println!();
             }
 
             // tags1
-            for tags1 in results.tags1.iter() {
-                console.info(format!("Popular {}:", tags1.header.title));
-                do_print_search_information(&tags1.comics, false, None);
+            for tags1 in results.tags1().iter() {
+                console.info(format!("Popular {}:", tags1.header().title()));
+                do_print_search_information(tags1.comics(), false, None);
                 println!();
             }
             // tags2
-            for tags2 in results.tags2.iter() {
-                console.info(format!("Popular {}:", tags2.header.title));
-                do_print_search_information(&tags2.comics, false, None);
+            for tags2 in results.tags2().iter() {
+                console.info(format!("Popular {}:", tags2.header().title()));
+                do_print_search_information(tags2.comics(), false, None);
                 println!();
             }
 
             // completed
-            for completed in results.completed.iter() {
-                console.info(format!("{}:", completed.header.title));
-                do_print_search_information(&completed.comics, false, None);
+            for completed in results.completed().iter() {
+                console.info(format!("{}:", completed.header().title()));
+                do_print_search_information(completed.comics(), false, None);
                 println!();
             }
 

--- a/tosho/src/impl/kmkc/common.rs
+++ b/tosho/src/impl/kmkc/common.rs
@@ -17,7 +17,7 @@ use crate::{
 use super::config::Config;
 
 pub(super) fn do_print_search_information(
-    results: Vec<TitleNode>,
+    results: &[TitleNode],
     with_number: bool,
     spacing: Option<usize>,
 ) {
@@ -165,12 +165,21 @@ pub(super) async fn common_purchase_select(
 
     console.info("Your current point balance:");
     let total_bal = user_point
-        .point
+        .point()
         .total_point()
         .to_formatted_string(&Locale::en);
-    let paid_point = user_point.point.paid_point.to_formatted_string(&Locale::en);
-    let free_point = user_point.point.free_point.to_formatted_string(&Locale::en);
-    let premium_ticket = user_point.ticket.total_num.to_formatted_string(&Locale::en);
+    let paid_point = user_point
+        .point()
+        .paid_point()
+        .to_formatted_string(&Locale::en);
+    let free_point = user_point
+        .point()
+        .free_point()
+        .to_formatted_string(&Locale::en);
+    let premium_ticket = user_point
+        .ticket()
+        .total_num()
+        .to_formatted_string(&Locale::en);
     console.info(cformat!(
         "  - <bold>Total:</> <cyan!,bold><reverse>{}</>c</cyan!,bold>",
         total_bal

--- a/tosho/src/impl/kmkc/download.rs
+++ b/tosho/src/impl/kmkc/download.rs
@@ -175,7 +175,7 @@ pub(crate) async fn kmkc_download(
                 return 1;
             }
 
-            let mut wallet_copy = user_point.point.point.clone();
+            let mut wallet_copy = user_point.point.point().clone();
             let mut ticket_entry = user_point.ticket.clone();
             console.info(format!("Downloading {} chapters...", results.len()));
             let mut download_chapters = vec![];

--- a/tosho/src/impl/kmkc/favorites.rs
+++ b/tosho/src/impl/kmkc/favorites.rs
@@ -38,7 +38,7 @@ pub(crate) async fn kmkc_my_favorites(
                 mapped_favorites.len()
             ));
 
-            do_print_search_information(mapped_favorites, false, None);
+            do_print_search_information(&mapped_favorites, false, None);
 
             0
         }

--- a/tosho/src/impl/kmkc/favorites.rs
+++ b/tosho/src/impl/kmkc/favorites.rs
@@ -18,16 +18,19 @@ pub(crate) async fn kmkc_my_favorites(
 
     match results {
         Ok(results) => {
-            if results.favorites.is_empty() {
+            if results.favorites().is_empty() {
                 console.error("You don't have any favorites.");
                 return 0;
             }
 
             let mapped_favorites: Vec<tosho_kmkc::models::TitleNode> = results
-                .favorites
+                .favorites()
                 .iter()
                 .filter_map(|favorite| {
-                    let title = results.titles.iter().find(|title| title.id == favorite.id);
+                    let title = results
+                        .titles()
+                        .iter()
+                        .find(|title| title.id() == favorite.id());
 
                     title.cloned()
                 })

--- a/tosho/src/impl/kmkc/manga.rs
+++ b/tosho/src/impl/kmkc/manga.rs
@@ -64,7 +64,7 @@ pub(crate) async fn kmkc_search_weekly(
 
             let mut titles = vec![];
             for title_id in title_ids_list {
-                let find_title = results.titles().iter().find(|t| t.id == title_id);
+                let find_title = results.titles().iter().find(|t| t.id() == title_id);
 
                 if let Some(title) = find_title {
                     titles.push(title.clone());
@@ -140,7 +140,7 @@ pub(crate) async fn kmkc_title_info(
             let result = results.first().unwrap();
 
             let mut genre_results = vec![];
-            if !result.genre_ids.is_empty() {
+            if !result.genre_ids().is_empty() {
                 let genre_resp = client.get_genres().await;
                 match genre_resp {
                     Err(e) => {
@@ -155,11 +155,11 @@ pub(crate) async fn kmkc_title_info(
             if show_chapters {
                 console.info(cformat!(
                     "Fetching <magenta,bold>{}</> <bold>{}</bold> chapters information...",
-                    &result.title,
-                    result.episode_ids.len()
+                    result.title(),
+                    result.episode_ids().len()
                 ));
 
-                for chunk_eps in result.episode_ids.chunks(50) {
+                for chunk_eps in result.episode_ids().chunks(50) {
                     let chap_req = client.get_episodes(chunk_eps.to_vec()).await;
 
                     match chap_req {
@@ -175,13 +175,13 @@ pub(crate) async fn kmkc_title_info(
             }
 
             let manga_url = format!("https://{}/title/{}", &*BASE_HOST, title_id);
-            let linked = linkify!(&manga_url, &result.title);
+            let linked = linkify!(&manga_url, result.title());
 
             console.info(cformat!(
                 "Title information for <magenta,bold>{}</>",
                 linked,
             ));
-            console.info(cformat!("  <s>Author</>: {}", result.author));
+            console.info(cformat!("  <s>Author</>: {}", result.author()));
 
             if !genre_results.is_empty() {
                 console.info(cformat!(
@@ -189,43 +189,43 @@ pub(crate) async fn kmkc_title_info(
                     format_tags(&genre_results)
                 ));
             }
-            if result.magazine != MagazineCategory::Undefined {
+            if result.magazine() != MagazineCategory::Undefined {
                 console.info(cformat!(
                     "  <s>Magazine</>: {}",
-                    result.magazine.pretty_name()
+                    result.magazine().pretty_name()
                 ));
             }
 
             console.info(cformat!("  <s>Summary</>"));
-            if !result.summary.is_empty() {
-                console.info(cformat!("   <blue>{}</>", result.summary));
+            if !result.summary().is_empty() {
+                console.info(cformat!("   <blue>{}</>", result.summary()));
             }
-            let split_desc: Vec<&str> = result.description.split('\n').collect();
+            let split_desc: Vec<&str> = result.description().split('\n').collect();
             for desc in split_desc {
                 console.info(format!("    {}", desc));
             }
 
-            if !result.notice.is_empty() {
-                console.warn(cformat!("  <s>Notice</>: {}", result.notice));
+            if !result.notice().is_empty() {
+                console.warn(cformat!("  <s>Notice</>: {}", result.notice()));
             }
 
             println!();
             console.info(cformat!(
                 "  <s>Chapters</>: {} chapters",
-                result.episode_ids.len()
+                result.episode_ids().len()
             ));
             if show_chapters && chapters_info.is_empty() {
                 console.warn("   <red,s>Error</>: Unable to get chapters information");
                 println!();
             } else if show_chapters && !chapters_info.is_empty() {
                 for chapter in chapters_info {
-                    let episode_url = format!("{}/episode/{}", manga_url, chapter.id);
-                    let ep_linked = linkify!(&episode_url, &chapter.title);
+                    let episode_url = format!("{}/episode/{}", manga_url, chapter.id());
+                    let ep_linked = linkify!(&episode_url, chapter.title());
 
-                    let mut text_info = cformat!("    <s>{}</> ({})", ep_linked, chapter.id);
-                    match chapter.badge {
+                    let mut text_info = cformat!("    <s>{}</> ({})", ep_linked, chapter.id());
+                    match chapter.badge() {
                         tosho_kmkc::models::EpisodeBadge::Purchaseable => {
-                            if chapter.ticket_rental.into() {
+                            if chapter.ticket_rental().into() {
                                 let ticket_emote = if console.is_modern() {
                                     "🎫"
                                 } else {
@@ -241,7 +241,7 @@ pub(crate) async fn kmkc_title_info(
                                 text_info = cformat!(
                                     "{} [<green,bold,reverse>P{}</>]",
                                     text_info,
-                                    chapter.point
+                                    chapter.point()
                                 );
                             }
                         }
@@ -252,7 +252,7 @@ pub(crate) async fn kmkc_title_info(
                             text_info = cformat!("{} [<green,bold>Purchased</>]", text_info);
                         }
                         tosho_kmkc::models::EpisodeBadge::Rental => {
-                            if let Some(rental_time) = chapter.rental_rest_time {
+                            if let Some(rental_time) = chapter.rental_rest_time() {
                                 text_info = cformat!(
                                     "{} [<yellow,bold>Renting: {}</>]",
                                     text_info,
@@ -263,13 +263,13 @@ pub(crate) async fn kmkc_title_info(
                     }
 
                     console.info(&text_info);
-                    let st_fmt = chapter.start_time.format("%b %d, %Y");
+                    let st_fmt = chapter.start_time().format("%b %d, %Y");
                     console.info(cformat!("     <s>Published</>: {}", st_fmt));
                 }
                 println!();
             }
 
-            if let Some(next_update) = &result.next_update {
+            if let Some(next_update) = result.next_update() {
                 console.info(cformat!("  <s>Next update</>: {}", next_update));
             }
 

--- a/tosho/src/impl/kmkc/purchases.rs
+++ b/tosho/src/impl/kmkc/purchases.rs
@@ -35,7 +35,7 @@ pub(crate) async fn kmkc_purchase(
                 if chapter.is_available() {
                     console.warn(cformat!(
                         "Chapter <m,s>{}</> is already purchased, skipping",
-                        chapter.title
+                        chapter.title()
                     ));
                     continue;
                 }
@@ -46,7 +46,7 @@ pub(crate) async fn kmkc_purchase(
                     // }
                     ticketing_claim.push((
                         chapter,
-                        TicketInfoType::Title(ticket_entry.info.title.clone().unwrap()),
+                        TicketInfoType::Title(ticket_entry.info().title().unwrap()),
                     ));
                     ticket_entry.subtract_title();
                 } else if chapter.is_ticketable() && ticket_entry.is_premium_available() {
@@ -55,11 +55,11 @@ pub(crate) async fn kmkc_purchase(
                     // }
                     ticketing_claim.push((
                         chapter,
-                        TicketInfoType::Premium(ticket_entry.info.premium.clone().unwrap()),
+                        TicketInfoType::Premium(ticket_entry.info().premium().unwrap()),
                     ));
                     ticket_entry.subtract_premium();
-                } else if wallet_copy.can_purchase(chapter.point.try_into().unwrap_or(0)) {
-                    wallet_copy.subtract(chapter.point.try_into().unwrap_or(0));
+                } else if wallet_copy.can_purchase(chapter.point().try_into().unwrap_or(0)) {
+                    wallet_copy.subtract(chapter.point().try_into().unwrap_or(0));
                     // if chapter.bonus_point > 0 {
                     //     chapter_point_back.push(chapter.clone());
                     // }
@@ -97,7 +97,7 @@ pub(crate) async fn kmkc_purchase(
                 ));
 
                 let result = client
-                    .claim_episode_with_ticket(chapter.id, &ticket_info)
+                    .claim_episode_with_ticket(chapter.id(), &ticket_info)
                     .await;
 
                 if let Err(error) = result {
@@ -220,10 +220,10 @@ pub(crate) async fn kmkc_purchased(
             ));
 
             for result in results {
-                let manga_url = format!("https://{}/title/{}", &*BASE_HOST, result.id);
-                let linked = linkify!(&manga_url, &result.title);
+                let manga_url = format!("https://{}/title/{}", &*BASE_HOST, result.id());
+                let linked = linkify!(&manga_url, result.title());
 
-                console.info(cformat!("  {} ({})", linked, result.id));
+                console.info(cformat!("  {} ({})", linked, result.id()));
                 console.info(format!("   {}", manga_url));
             }
 
@@ -265,13 +265,13 @@ pub(crate) async fn kmkc_purchase_precalculate(
                 if chapter.is_ticketable() && ticket_entry.is_title_available() {
                     ticketing_claim.push((
                         chapter,
-                        TicketInfoType::Title(ticket_entry.info.title.clone().unwrap()),
+                        TicketInfoType::Title(ticket_entry.info().title().unwrap()),
                     ));
                     ticket_entry.subtract_title();
                 } else if chapter.is_ticketable() && ticket_entry.is_premium_available() {
                     ticketing_claim.push((
                         chapter,
-                        TicketInfoType::Premium(ticket_entry.info.premium.clone().unwrap()),
+                        TicketInfoType::Premium(ticket_entry.info().premium().unwrap()),
                     ));
                     ticket_entry.subtract_premium();
                 } else {
@@ -289,7 +289,7 @@ pub(crate) async fn kmkc_purchase_precalculate(
 
             let coin_total = chapter_point_claim
                 .iter()
-                .map(|ch| ch.point)
+                .map(|ch| ch.point())
                 .sum::<i32>()
                 .to_formatted_string(&Locale::en);
             let ticket_total = ticketing_claim.len().to_formatted_string(&Locale::en);

--- a/tosho/src/impl/kmkc/purchases.rs
+++ b/tosho/src/impl/kmkc/purchases.rs
@@ -25,7 +25,7 @@ pub(crate) async fn kmkc_purchase(
                 return 1;
             }
 
-            let mut wallet_copy = user_point.point.point.clone();
+            let mut wallet_copy = user_point.point.point().clone();
             let mut ticket_entry = user_point.ticket.clone();
 
             let mut chapter_point_claim: Vec<EpisodeNode> = vec![];
@@ -116,7 +116,7 @@ pub(crate) async fn kmkc_purchase(
                 let temp_chapter_claim: Vec<&EpisodeNode> =
                     chapter_point_claim.iter().collect::<Vec<&EpisodeNode>>();
 
-                let mut mutable_point = user_point.point.point.clone();
+                let mut mutable_point = user_point.point.point().clone();
 
                 let result = client
                     .claim_episodes(temp_chapter_claim, &mut mutable_point)

--- a/tosho/src/impl/kmkc/rankings.rs
+++ b/tosho/src/impl/kmkc/rankings.rs
@@ -64,19 +64,19 @@ pub(crate) async fn kmkc_home_rankings(
             1
         }
         Ok(results) => {
-            if results.titles.is_empty() {
+            if results.titles().is_empty() {
                 console.error("There are no rankings available for some reason.");
                 return 1;
             }
 
             console.info(cformat!(
                 "Fetching <m,s>{}</> titles from <m,s>{}</>",
-                results.titles.len(),
+                results.titles().len(),
                 rank_tab.name
             ));
 
             let all_titles = client
-                .get_titles(results.titles.iter().map(|t| t.id).collect())
+                .get_titles(results.titles().iter().map(|t| t.id()).collect())
                 .await;
 
             match all_titles {
@@ -95,7 +95,7 @@ pub(crate) async fn kmkc_home_rankings(
                         rank_tab.name,
                         titles.len()
                     ));
-                    do_print_search_information(titles, true, None);
+                    do_print_search_information(&titles, true, None);
                     0
                 }
             }

--- a/tosho/src/impl/models.rs
+++ b/tosho/src/impl/models.rs
@@ -167,14 +167,14 @@ impl From<&ComicEpisodeInfo> for ChapterDetailDump {
     }
 }
 
-impl From<MangaChapterDetail> for ChapterDetailDump {
+impl From<&MangaChapterDetail> for ChapterDetailDump {
     /// Convert from [`tosho_sjv::models::MangaChapterDetail`] into [`ChapterDetailDump`]
     /// `_info.json` format.
-    fn from(value: MangaChapterDetail) -> Self {
+    fn from(value: &MangaChapterDetail) -> Self {
         Self {
             main_name: value.pretty_title(),
-            id: (value.id as u64).into(),
-            timestamp: value.published_at.map(|d| d.timestamp()),
+            id: (value.id() as u64).into(),
+            timestamp: value.published_at().map(|d| d.timestamp()),
             sub_name: None,
         }
     }

--- a/tosho/src/impl/models.rs
+++ b/tosho/src/impl/models.rs
@@ -180,14 +180,14 @@ impl From<MangaChapterDetail> for ChapterDetailDump {
     }
 }
 
-impl From<Chapter> for ChapterDetailDump {
+impl From<&Chapter> for ChapterDetailDump {
     /// Convert from [`tosho_rbean::models::Chapter`] into [`ChapterDetailDump`]
     /// `_info.json` format.
-    fn from(value: Chapter) -> Self {
+    fn from(value: &Chapter) -> Self {
         Self {
-            id: value.uuid.clone().into(),
+            id: value.uuid().to_string().into(),
             main_name: value.formatted_title(),
-            timestamp: value.published.map(|d| d.timestamp()),
+            timestamp: value.published().map(|d| d.timestamp()),
             sub_name: None,
         }
     }

--- a/tosho/src/impl/models.rs
+++ b/tosho/src/impl/models.rs
@@ -146,24 +146,24 @@ impl From<EpisodeNode> for ChapterDetailDump {
     }
 }
 
-impl From<ComicEpisodeInfoNode> for ChapterDetailDump {
+impl From<&ComicEpisodeInfoNode> for ChapterDetailDump {
     /// Convert from [`tosho_amap::models::ComicEpisodeInfoNode`] into [`ChapterDetailDump`]
     /// `_info.json` format.
-    fn from(value: ComicEpisodeInfoNode) -> Self {
+    fn from(value: &ComicEpisodeInfoNode) -> Self {
         Self {
-            main_name: value.title,
-            id: value.id.into(),
-            timestamp: Some(value.update_date as i64),
+            main_name: value.title().to_string(),
+            id: value.id().into(),
+            timestamp: Some(value.update_date() as i64),
             sub_name: None,
         }
     }
 }
 
-impl From<ComicEpisodeInfo> for ChapterDetailDump {
+impl From<&ComicEpisodeInfo> for ChapterDetailDump {
     /// Convert from [`tosho_amap::models::ComicEpisodeInfo`] into [`ChapterDetailDump`]
     /// `_info.json` format.
-    fn from(value: ComicEpisodeInfo) -> Self {
-        Self::from(value.info)
+    fn from(value: &ComicEpisodeInfo) -> Self {
+        Self::from(value.info())
     }
 }
 

--- a/tosho/src/impl/models.rs
+++ b/tosho/src/impl/models.rs
@@ -193,15 +193,19 @@ impl From<&Chapter> for ChapterDetailDump {
     }
 }
 
-impl From<MPChapter> for ChapterDetailDump {
+impl From<&MPChapter> for ChapterDetailDump {
     /// Convert from [`tosho_mplus::proto::Chapter`] into [`ChapterDetailDump`]
     /// `_info.json` format.
-    fn from(value: MPChapter) -> Self {
+    fn from(value: &MPChapter) -> Self {
         Self {
-            id: value.chapter_id.into(),
-            main_name: value.title,
-            timestamp: Some(value.published_at),
-            sub_name: value.subtitle,
+            id: value.chapter_id().into(),
+            main_name: value.title().to_string(),
+            timestamp: Some(value.published_at()),
+            sub_name: if value.subtitle().is_empty() {
+                None
+            } else {
+                Some(value.subtitle().to_string())
+            },
         }
     }
 }

--- a/tosho/src/impl/models.rs
+++ b/tosho/src/impl/models.rs
@@ -131,15 +131,15 @@ impl From<&ChapterV2> for ChapterDetailDump {
     }
 }
 
-impl From<EpisodeNode> for ChapterDetailDump {
+impl From<&EpisodeNode> for ChapterDetailDump {
     /// Convert from [`tosho_kmkc::models::EpisodeNode`] into [`ChapterDetailDump`]
     /// `_info.json` format.
-    fn from(value: EpisodeNode) -> Self {
-        let start_time_ts = value.start_time.timestamp();
+    fn from(value: &EpisodeNode) -> Self {
+        let start_time_ts = value.start_time().timestamp();
 
         Self {
-            main_name: value.title,
-            id: (value.id as u64).into(),
+            main_name: value.title().to_string(),
+            id: (value.id() as u64).into(),
             timestamp: Some(start_time_ts),
             sub_name: None,
         }

--- a/tosho/src/impl/mplus/accounts.rs
+++ b/tosho/src/impl/mplus/accounts.rs
@@ -91,10 +91,8 @@ pub(crate) async fn mplus_auth_session(
                 Ok(tosho_mplus::APIResponse::Success(account_resp)) => {
                     let mut final_config = config.clone();
 
-                    if let Some(username) = account_resp.user_name {
-                        if !username.is_empty() {
-                            final_config = final_config.with_username(&username);
-                        }
+                    if !account_resp.user_name().is_empty() {
+                        final_config = final_config.with_username(account_resp.user_name());
                     }
 
                     console.info(cformat!(
@@ -187,13 +185,13 @@ pub async fn mplus_account_info(
             console.info(cformat!("  <bold>Session:</> {}", acc_info.session));
             console.info(cformat!("  <bold>Type:</> {}", acc_info.r#type().to_name()));
 
-            let mut username = account_resp.user_name.clone();
+            let mut username = account_resp.user_name();
             if username.is_empty() {
-                username = "[No username]".to_string();
+                username = "[No username]";
             }
 
             console.info(cformat!("  <bold>Username:</> {}", username));
-            let subs_info = account_resp.subscription.unwrap_or_default();
+            let subs_info = account_resp.subscription().cloned().unwrap_or_default();
             console.info(cformat!(
                 "  <bold>Subscription:</> {}",
                 subs_info.plan().to_name()
@@ -201,7 +199,7 @@ pub async fn mplus_account_info(
 
             console.info(cformat!(
                 "  <bold>Notify news?</> {}",
-                if account_resp.news_notification {
+                if account_resp.news_notification() {
                     "Yes"
                 } else {
                     "No"
@@ -210,7 +208,7 @@ pub async fn mplus_account_info(
 
             console.info(cformat!(
                 "  <bold>Notify chapter update?</> {}",
-                if account_resp.chapter_notification {
+                if account_resp.chapter_notification() {
                     "Yes"
                 } else {
                     "No"

--- a/tosho/src/impl/mplus/favorites.rs
+++ b/tosho/src/impl/mplus/favorites.rs
@@ -18,17 +18,17 @@ pub(crate) async fn mplus_my_favorites(
 
     match results {
         Ok(tosho_mplus::APIResponse::Success(results)) => {
-            if results.titles.is_empty() {
+            if results.titles().is_empty() {
                 console.warn("You don't have any favorites.");
                 return 0;
             }
 
             console.info(cformat!(
                 "Your favorites list (<m,s>{}</> results):",
-                results.titles.len()
+                results.titles().len()
             ));
 
-            do_print_search_information(&results.titles, false, None);
+            do_print_search_information(results.titles(), false, None);
 
             0
         }

--- a/tosho/src/impl/mplus/manga.rs
+++ b/tosho/src/impl/mplus/manga.rs
@@ -45,7 +45,7 @@ pub(crate) async fn mplus_search(
 fn format_tags(tags: &[Tag]) -> String {
     let parsed_tags = tags
         .iter()
-        .map(|tag| cformat!("<p(244),reverse,bold>{}</>", tag.slug))
+        .map(|tag| cformat!("<p(244),reverse,bold>{}</>", tag.slug()))
         .collect::<Vec<String>>()
         .join(", ");
     parsed_tags

--- a/tosho/src/impl/mplus/manga.rs
+++ b/tosho/src/impl/mplus/manga.rs
@@ -26,7 +26,7 @@ pub(crate) async fn mplus_search(
             }
 
             let merged_titles: Vec<tosho_mplus::proto::Title> =
-                results.iter().flat_map(|x| x.titles.clone()).collect();
+                results.iter().flat_map(|x| x.titles().to_vec()).collect();
             let filtered = search_manga_by_text(&merged_titles, query);
 
             if filtered.is_empty() {
@@ -55,7 +55,7 @@ fn format_other_languages(title_lang: &[TitleLanguages]) -> String {
     let parsed_lang = title_lang
         .iter()
         .map(|lang| {
-            let lang_url = format!("https://{}/titles/{}", &*BASE_HOST, lang.id);
+            let lang_url = format!("https://{}/titles/{}", &*BASE_HOST, lang.id());
             let linked = linkify!(&lang_url, &lang.language().pretty_name());
             cformat!("<p(244),reverse,bold>{}</>", linked)
         })
@@ -80,42 +80,48 @@ pub(crate) async fn mplus_title_info(
 
     match result {
         Ok(tosho_mplus::APIResponse::Success(title_info)) => {
-            let title = title_info.title.clone().unwrap();
-            let manga_url = format!("https://{}/titles/{}", &*BASE_HOST, title.id);
-            let linked = linkify!(manga_url, &title.title);
+            let title = title_info.title().unwrap();
+            let manga_url = format!("https://{}/titles/{}", &*BASE_HOST, title.id());
+            let linked = linkify!(manga_url, title.title());
 
             console.info(cformat!(
                 "Title information for <magenta,bold>{}</>",
                 linked,
             ));
 
-            let title_labels = title_info.title_labels.clone().unwrap_or_default();
             let mut merged_labels = Vec::new();
-            if title_labels.release_schedule() != TitleReleaseSchedule::None {
-                merged_labels.push(cformat!(
-                    "<y!,bold>[<rev>{}</rev>]</y!,bold>",
-                    title_labels.release_schedule().pretty_name()
-                ));
-            }
-            if title_labels.simulpublish {
-                merged_labels.push(cformat!("<r!,bold>[<rev>Simulpub</rev>]</r!,bold>"));
-            }
-            match title_labels.plan_type() {
-                SubscriptionPlan::Basic => merged_labels.push(cformat!("[<bold>Basic</>]")),
-                SubscriptionPlan::Standard => merged_labels.push(cformat!(
-                    "<c!,bold>[<rev>Standard / Deluxe</rev>]</c!,bold>"
-                )),
-                SubscriptionPlan::Deluxe => {
-                    merged_labels.push(cformat!("<m!,bold>[<rev>Deluxe</rev>]</m!,bold>"))
+            let mut title_plan_type = SubscriptionPlan::Basic;
+            if let Some(title_labels) = title_info.title_labels() {
+                if title_labels.release_schedule() != TitleReleaseSchedule::None {
+                    merged_labels.push(cformat!(
+                        "<y!,bold>[<rev>{}</rev>]</y!,bold>",
+                        title_labels.release_schedule().pretty_name()
+                    ));
                 }
+                if title_labels.simulpublish() {
+                    merged_labels.push(cformat!("<r!,bold>[<rev>Simulpub</rev>]</r!,bold>"));
+                }
+                match title_labels.plan_type() {
+                    SubscriptionPlan::Basic => merged_labels.push(cformat!("[<bold>Basic</>]")),
+                    SubscriptionPlan::Standard => merged_labels.push(cformat!(
+                        "<c!,bold>[<rev>Standard / Deluxe</rev>]</c!,bold>"
+                    )),
+                    SubscriptionPlan::Deluxe => {
+                        merged_labels.push(cformat!("<m!,bold>[<rev>Deluxe</rev>]</m!,bold>"))
+                    }
+                }
+                title_plan_type = title_labels.plan_type();
             }
 
-            console.info(cformat!("  {}", merged_labels.join(" ")));
-            console.info(cformat!("  <s>Author</>: {}", title.author));
-            if !title_info.tags.is_empty() {
+            if !merged_labels.is_empty() {
+                console.info(cformat!("  {}", merged_labels.join(" ")));
+            }
+
+            console.info(cformat!("  <s>Author</>: {}", title.author()));
+            if !title_info.tags().is_empty() {
                 console.info(cformat!(
                     "  <s>Genre/Tags</>: {}",
-                    format_tags(&title_info.tags)
+                    format_tags(title_info.tags())
                 ));
             }
             console.info(cformat!(
@@ -123,9 +129,9 @@ pub(crate) async fn mplus_title_info(
                 title.language().pretty_name()
             ));
             let filtered_alt_langs = title_info
-                .other_languages
+                .other_languages()
                 .iter()
-                .filter_map(|x| if x.id != title.id { Some(*x) } else { None })
+                .filter_map(|x| if x.id() != title.id() { Some(*x) } else { None })
                 .collect::<Vec<TitleLanguages>>();
             if !filtered_alt_langs.is_empty() {
                 console.info(cformat!(
@@ -134,7 +140,7 @@ pub(crate) async fn mplus_title_info(
                 ));
             }
             console.info(cformat!("  <s>Summary</>"));
-            let split_desc = title_info.overview.split('\n');
+            let split_desc = title_info.overview().split('\n');
             for desc in split_desc {
                 console.info(format!("    {}", desc));
             }
@@ -147,35 +153,39 @@ pub(crate) async fn mplus_title_info(
             ));
 
             let title_ticket: Vec<u64> = title_info
-                .ticket_chapters
+                .ticket_chapters()
                 .iter()
-                .map(|x| x.chapter_id)
+                .map(|x| x.chapter_id())
                 .collect();
 
-            let user_plan = title_info.user_subscription.unwrap_or_default().plan();
+            let user_plan = title_info
+                .user_subscription()
+                .map(|d| d.plan())
+                .unwrap_or(SubscriptionPlan::Basic);
 
             if show_chapters && !all_chapters.is_empty() {
                 for chapter in all_chapters {
-                    let ch_url = format!("https://{}/viewer/{}", &*BASE_HOST, chapter.chapter_id);
-                    let linked_ch = linkify!(ch_url, &chapter.title);
-                    let mut base_txt = cformat!("    <s>{}</> ({})", linked_ch, chapter.chapter_id);
+                    let ch_url = format!("https://{}/viewer/{}", &*BASE_HOST, chapter.chapter_id());
+                    let linked_ch = linkify!(ch_url, chapter.title());
+                    let mut base_txt =
+                        cformat!("    <s>{}</> ({})", linked_ch, chapter.chapter_id());
                     base_txt =
-                        if chapter.is_ticketed() || title_ticket.contains(&chapter.chapter_id) {
+                        if chapter.is_ticketed() || title_ticket.contains(&chapter.chapter_id()) {
                             cformat!("{} <y,strong>[Ticket]</y,strong>", base_txt)
                         } else if chapter.is_free() {
                             cformat!("{} <g,strong>[FREE]</g,strong>", base_txt)
-                        } else if user_plan >= title_labels.plan_type() {
+                        } else if user_plan >= title_plan_type {
                             cformat!("{} [<c!,strong>Subscription</>]", base_txt)
                         } else {
                             cformat!("{} [<r!,strong>Locked</>]", base_txt)
                         };
 
                     console.info(&base_txt);
-                    if let Some(subtitle) = &chapter.subtitle {
-                        console.info(cformat!("     <s>{}</>", subtitle));
+                    if !chapter.subtitle().is_empty() {
+                        console.info(cformat!("     <s>{}</>", chapter.subtitle()));
                     }
 
-                    if let Some(pub_at_fmt) = unix_timestamp_to_string(chapter.published_at) {
+                    if let Some(pub_at_fmt) = unix_timestamp_to_string(chapter.published_at()) {
                         console.info(cformat!("      <s>Published</>: {}", pub_at_fmt));
                     }
                 }
@@ -183,22 +193,22 @@ pub(crate) async fn mplus_title_info(
                 println!();
             }
 
-            if let Some(next_upd) = title_info.next_update {
-                if let Some(next_upd_fmt) = unix_timestamp_to_string(next_upd) {
+            if title_info.next_update() > 0 {
+                if let Some(next_upd_fmt) = unix_timestamp_to_string(title_info.next_update()) {
                     console.info(cformat!("  <s>Next Update</>: {}", next_upd_fmt));
                 }
             }
 
             console.info(cformat!("  <s>Your Plan</>: {}", user_plan.to_name()));
 
-            if show_related && !title_info.recommended_titles.is_empty() {
+            if show_related && !title_info.recommended_titles().is_empty() {
                 println!();
                 console.info(cformat!(
                     "  <s>Related titles</>: {} titles",
-                    title_info.recommended_titles.len()
+                    title_info.recommended_titles().len()
                 ));
 
-                do_print_search_information(&title_info.recommended_titles, false, Some(3));
+                do_print_search_information(title_info.recommended_titles(), false, Some(3));
             }
 
             0

--- a/tosho/src/impl/mplus/rankings.rs
+++ b/tosho/src/impl/mplus/rankings.rs
@@ -68,9 +68,9 @@ pub(crate) async fn mplus_home_rankings(
     match results {
         Ok(tosho_mplus::APIResponse::Success(results)) => {
             let all_titles: Vec<tosho_mplus::proto::Title> = results
-                .titles
+                .titles()
                 .iter()
-                .map(|title| title.titles.first().unwrap().clone())
+                .map(|title| title.titles().first().unwrap().clone())
                 .collect();
 
             console.info(cformat!(

--- a/tosho/src/impl/musq/accounts.rs
+++ b/tosho/src/impl/musq/accounts.rs
@@ -156,11 +156,11 @@ pub async fn musq_account_info(
             console.info(cformat!("  <bold>Session:</> {}", acc_info.session));
             console.info(cformat!("  <bold>Type:</> {}", acc_info.r#type().to_name()));
             console.info(cformat!("  <bold>Registered?</> {}", account.registered()));
-            if !account.devices.is_empty() {
+            if !account.devices().is_empty() {
                 console.info(cformat!("  <bold>Devices:</>"));
-                for device in account.devices {
-                    let device_name = device.name;
-                    let device_id = device.id;
+                for device in account.devices() {
+                    let device_name = device.name();
+                    let device_id = device.id();
                     console.info(cformat!("    - <bold>{}:</> ({})", device_name, device_id));
                 }
             }
@@ -188,11 +188,11 @@ pub async fn musq_account_balance(
     match user_shop {
         Ok(user_shop) => {
             console.info("Your current point balance:");
-            let user_point = user_shop.user_point.unwrap_or_default();
+            let user_point = user_shop.user_point().unwrap_or_default();
             let total_bal = user_point.sum().to_formatted_string(&Locale::en);
-            let paid_point = user_point.paid.to_formatted_string(&Locale::en);
-            let xp_point = user_point.event.to_formatted_string(&Locale::en);
-            let free_point = user_point.free.to_formatted_string(&Locale::en);
+            let paid_point = user_point.paid().to_formatted_string(&Locale::en);
+            let xp_point = user_point.event().to_formatted_string(&Locale::en);
+            let free_point = user_point.free().to_formatted_string(&Locale::en);
             console.info(cformat!(
                 "  - <bold>Total:</> <cyan!,bold><reverse>{}</>c</cyan!,bold>",
                 total_bal
@@ -209,10 +209,10 @@ pub async fn musq_account_balance(
                 "  - <bold>Free point:</> <green,bold><reverse>{}</>c</green,bold>",
                 free_point
             ));
-            let subs_status = if !user_shop.subscriptions.is_empty() {
-                let first_subs = user_shop.subscriptions.first().unwrap();
+            let subs_status = if !user_shop.subscriptions().is_empty() {
+                let first_subs = user_shop.subscriptions().first().unwrap();
                 let status = first_subs.status().as_name();
-                match unix_timestamp_to_string(first_subs.end) {
+                match unix_timestamp_to_string(first_subs.end()) {
                     Some(ends_at) => cformat!(
                         "<bold><blue>{}</blue> Subscription</bold> (Ends at: <s>{}</>)",
                         status,

--- a/tosho/src/impl/musq/download.rs
+++ b/tosho/src/impl/musq/download.rs
@@ -84,10 +84,11 @@ pub(crate) struct MUDownloadCliConfig {
 }
 
 fn create_chapters_info(manga_detail: MangaDetailV2) -> MangaDetailDump {
-    let mut chapters: Vec<ChapterDetailDump> = vec![];
-    for chapter in manga_detail.chapters() {
-        chapters.push(ChapterDetailDump::from(chapter));
-    }
+    let chapters: Vec<ChapterDetailDump> = manga_detail
+        .chapters()
+        .iter()
+        .map(ChapterDetailDump::from)
+        .collect();
 
     MangaDetailDump::new(
         manga_detail.title().to_string(),

--- a/tosho/src/impl/musq/favorites.rs
+++ b/tosho/src/impl/musq/favorites.rs
@@ -22,17 +22,17 @@ pub(crate) async fn musq_my_favorites(
             1
         }
         Ok(results) => {
-            if results.favorites.is_empty() {
+            if results.favorites().is_empty() {
                 console.error("You don't have any favorites.");
                 return 0;
             }
 
             console.info(cformat!(
                 "Your favorites list (<m,s>{}</> results):",
-                results.favorites.len()
+                results.favorites().len()
             ));
 
-            do_print_search_information(results.favorites, false, None);
+            do_print_search_information(results.favorites(), false, None);
 
             0
         }
@@ -57,17 +57,17 @@ pub(crate) async fn musq_my_history(
             1
         }
         Ok(results) => {
-            if results.history.is_empty() {
+            if results.history().is_empty() {
                 console.error("You don't have any reading history.");
                 return 0;
             }
 
             console.info(cformat!(
                 "Your read history (<m,s>{}</> results):",
-                results.history.len()
+                results.history().len()
             ));
 
-            do_print_search_information(results.history, false, None);
+            do_print_search_information(results.history(), false, None);
 
             0
         }

--- a/tosho/src/impl/musq/purchases.rs
+++ b/tosho/src/impl/musq/purchases.rs
@@ -38,24 +38,24 @@ pub(crate) async fn musq_purchase(
                 if !consume.is_possible() {
                     console.warn(cformat!(
                         "Unable to purchase chapter <magenta,bold>{}</> (ID: {}), insufficient point balance!",
-                        chapter.title, title_id
+                        chapter.title(), title_id
                     ));
                     failed_claimed
                         .push((chapter.clone(), "Insufficient point balance".to_string()));
                     continue;
                 }
 
-                user_point.free -= consume.get_free();
-                user_point.paid -= consume.get_paid();
-                user_point.event -= consume.get_event();
+                user_point.subtract_free(consume.get_free());
+                user_point.subtract_event(consume.get_event());
+                user_point.subtract_paid(consume.get_paid());
                 let img_chapter = client
-                    .get_chapter_images(chapter.id, tosho_musq::ImageQuality::High, Some(consume))
+                    .get_chapter_images(chapter.id(), tosho_musq::ImageQuality::High, Some(consume))
                     .await
                     .unwrap();
-                if img_chapter.blocks.is_empty() {
+                if img_chapter.blocks().is_empty() {
                     console.warn(cformat!(
                         "Unable to purchase chapter <magenta,bold>{}</> (ID: {}), no images found!",
-                        chapter.title,
+                        chapter.title(),
                         title_id
                     ));
                     failed_claimed.push((chapter.clone(), "Failed when claiming".to_string()));
@@ -77,8 +77,8 @@ pub(crate) async fn musq_purchase(
                 for (chapter, reason) in failed_claimed {
                     console.warn(cformat!(
                         "  - <bold>{}</> (ID: {}): <red,bold>{}</>",
-                        chapter.title,
-                        chapter.id,
+                        chapter.title(),
+                        chapter.id(),
                         reason
                     ));
                 }
@@ -105,7 +105,7 @@ pub(crate) async fn musq_purchase_precalculate(
             }
 
             console.info("Calculating chapters cost...");
-            let total_coin: u64 = results.iter().map(|c| c.price).sum();
+            let total_coin: u64 = results.iter().map(|c| c.price()).sum();
 
             let total_coin_fmt = total_coin.to_formatted_string(&Locale::en);
             let ch_count = results.len().to_formatted_string(&Locale::en);

--- a/tosho/src/impl/musq/rankings.rs
+++ b/tosho/src/impl/musq/rankings.rs
@@ -23,18 +23,18 @@ pub(crate) async fn musq_home_rankings(
             1
         }
         Ok(results) => {
-            if results.rankings.is_empty() {
+            if results.rankings().is_empty() {
                 console.error("There are no rankings available for some reason.");
                 return 1;
             }
 
             loop {
                 let rank_choices = results
-                    .rankings
+                    .rankings()
                     .iter()
                     .map(|r| ConsoleChoice {
-                        name: r.name.clone(),
-                        value: r.name.clone(),
+                        name: r.name().to_string(),
+                        value: r.name().to_string(),
                     })
                     .collect::<Vec<ConsoleChoice>>();
 
@@ -47,18 +47,18 @@ pub(crate) async fn musq_home_rankings(
                     }
                     Some(select) => {
                         let ranking = results
-                            .rankings
+                            .rankings()
                             .iter()
-                            .find(|r| r.name == select.name)
+                            .find(|&r| r.name() == select.name)
                             .unwrap();
 
                         console.info(cformat!(
                             "Ranking for <m,s>{}</> ({} titles):",
-                            ranking.name,
-                            ranking.titles.len()
+                            ranking.name(),
+                            ranking.titles().len()
                         ));
 
-                        do_print_search_information(ranking.titles.clone(), true, None);
+                        do_print_search_information(ranking.titles(), true, None);
                         println!();
                     }
                 }

--- a/tosho/src/impl/rbean/accounts.rs
+++ b/tosho/src/impl/rbean/accounts.rs
@@ -135,12 +135,12 @@ pub(crate) async fn rbean_account_info(
                 account.id
             ));
 
-            console.info(cformat!("  <s>ID</>: {}", acc_info.uuid));
-            console.info(cformat!("  <s>Email</>: {}", acc_info.email));
-            let username = acc_info.username.unwrap_or("[no username]".to_string());
+            console.info(cformat!("  <s>ID</>: {}", acc_info.uuid()));
+            console.info(cformat!("  <s>Email</>: {}", acc_info.email()));
+            let username = acc_info.username().unwrap_or("[no username]");
             console.info(cformat!("  <s>Username</>: {}", username));
 
-            if let Some(date_at) = acc_info.premium_expiration_date {
+            if let Some(date_at) = acc_info.premium_expiration_date() {
                 console.info(cformat!("  <s>Premium until</>: {}", date_at));
             }
 

--- a/tosho/src/impl/rbean/common.rs
+++ b/tosho/src/impl/rbean/common.rs
@@ -14,9 +14,9 @@ pub(super) fn do_print_single_information(
     let term = get_console(0);
     let spacing = spacing.unwrap_or(2);
 
-    let manga_url = format!("https://{}/series/{}", &*BASE_HOST, result.slug);
-    let linked = linkify!(&manga_url, &result.title);
-    let text_data = cformat!("<s>{}</s> ({})", linked, result.uuid);
+    let manga_url = format!("https://{}/series/{}", &*BASE_HOST, result.slug());
+    let linked = linkify!(&manga_url, &result.title());
+    let text_data = cformat!("<s>{}</s> ({})", linked, result.uuid());
 
     let pre_space = " ".repeat(spacing);
     let pre_space_lupd = " ".repeat(spacing + 1);
@@ -26,7 +26,7 @@ pub(super) fn do_print_single_information(
         true => term.info(format!("{}[{:02}] {}", pre_space, index + 1, text_data)),
         false => term.info(format!("{}{}", pre_space, text_data)),
     }
-    let updated_at = result.last_updated.format("%Y-%m-%d").to_string();
+    let updated_at = result.last_updated().format("%Y-%m-%d").to_string();
     term.info(cformat!(
         "{}<s>Last update</s>: {}",
         pre_space_lupd,
@@ -34,14 +34,16 @@ pub(super) fn do_print_single_information(
     ));
     term.info(format!("{}{}", pre_space_url, manga_url));
 
-    if let Some(chapter_info) = &result.latest_chapters {
+    if let Some(chapter_info) = result.latest_chapters() {
         println!();
         for chapter in chapter_info.iter() {
             let chapter_url = format!(
                 "https://{}/series/{}/chapter/{}",
-                &*BASE_HOST, result.slug, chapter.uuid
+                &*BASE_HOST,
+                result.slug(),
+                chapter.uuid()
             );
-            let linked = linkify!(&chapter_url, &format!("Chapter {}", chapter.chapter));
+            let linked = linkify!(&chapter_url, &format!("Chapter {}", chapter.chapter()));
             term.info(cformat!("{}<s>Chapter</s>: {}", pre_space_lupd, linked));
             term.info(format!("{}{}", pre_space_url, chapter_url));
         }

--- a/tosho/src/impl/rbean/config.rs
+++ b/tosho/src/impl/rbean/config.rs
@@ -85,13 +85,13 @@ impl From<RBLoginResponse> for Config {
             RBPlatform::Web => DeviceType::Web,
         };
 
-        let username = value.user.username.unwrap_or("[no username]".to_string());
+        let username = value.user.username().unwrap_or("[no username]").to_string();
 
         Self {
             id,
             username,
-            user_id: value.user.uuid,
-            email: value.user.email,
+            user_id: value.user.uuid().to_string(),
+            email: value.user.email().to_string(),
             access_token: value.token,
             refresh_token: value.refresh_token,
             expiry: value.expiry,

--- a/tosho/src/impl/rbean/config.rs
+++ b/tosho/src/impl/rbean/config.rs
@@ -102,15 +102,15 @@ impl From<RBLoginResponse> for Config {
 
 impl From<Config> for RBConfig {
     fn from(value: Config) -> Self {
-        Self {
-            token: value.access_token.clone(),
-            refresh_token: value.refresh_token.clone(),
-            platform: match value.platform() {
+        Self::new(
+            &value.access_token,
+            &value.refresh_token,
+            match value.platform() {
                 DeviceType::Android => RBPlatform::Android,
                 DeviceType::Apple => RBPlatform::Apple,
                 DeviceType::Web => RBPlatform::Web,
             },
-        }
+        )
     }
 }
 

--- a/tosho/src/impl/rbean/download.rs
+++ b/tosho/src/impl/rbean/download.rs
@@ -124,10 +124,8 @@ pub(crate) struct RBDownloadConfigCli {
 }
 
 fn create_chapters_info(title: &Manga, chapters: &[Chapter]) -> MangaDetailDump {
-    let mut dumped_chapters: Vec<ChapterDetailDump> = vec![];
-    for chapter in chapters {
-        dumped_chapters.push(ChapterDetailDump::from(chapter));
-    }
+    let dumped_chapters: Vec<ChapterDetailDump> =
+        chapters.iter().map(ChapterDetailDump::from).collect();
 
     let creators = title
         .creators()

--- a/tosho/src/impl/rbean/download.rs
+++ b/tosho/src/impl/rbean/download.rs
@@ -123,19 +123,23 @@ pub(crate) struct RBDownloadConfigCli {
     pub(crate) parallel: bool,
 }
 
-fn create_chapters_info(title: &Manga, chapters: Vec<Chapter>) -> MangaDetailDump {
+fn create_chapters_info(title: &Manga, chapters: &[Chapter]) -> MangaDetailDump {
     let mut dumped_chapters: Vec<ChapterDetailDump> = vec![];
     for chapter in chapters {
         dumped_chapters.push(ChapterDetailDump::from(chapter));
     }
 
     let creators = title
-        .creators
+        .creators()
         .iter()
-        .map(|cc| cc.name.clone())
+        .map(|cc| cc.name().to_string())
         .collect::<Vec<String>>();
 
-    MangaDetailDump::new(title.title.clone(), creators.join(", "), dumped_chapters)
+    MangaDetailDump::new(
+        title.title().to_string(),
+        creators.join(", "),
+        dumped_chapters,
+    )
 }
 
 fn get_output_directory(
@@ -165,8 +169,8 @@ fn do_chapter_select(
     console: &mut crate::term::Terminal,
 ) -> Vec<Chapter> {
     console.info("Title information:");
-    console.info(cformat!("  - <bold>ID:</> {}", result.uuid));
-    console.info(cformat!("  - <bold>Title:</> {}", result.title));
+    console.info(cformat!("  - <bold>ID:</> {}", result.uuid()));
+    console.info(cformat!("  - <bold>Title:</> {}", result.title()));
     console.info(cformat!(
         "  - <bold>Chapters:</> {} chapters",
         chapters_entry.len()
@@ -176,13 +180,13 @@ fn do_chapter_select(
         .iter()
         .filter(|&&ch| {
             // Hide unavailable chapters
-            ch.published.is_some() && !ch.upcoming
+            ch.published().is_some() && !ch.upcoming()
         })
         .filter_map(|&ch| {
             // Download chapter if it's free or user is premium
-            if ch.free_published.is_some() || user_info.is_premium {
+            if ch.free_published().is_some() || user_info.is_premium() {
                 Some(ConsoleChoice {
-                    name: ch.uuid.to_string(),
+                    name: ch.uuid().to_string(),
                     value: ch.formatted_title(),
                 })
             } else {
@@ -199,7 +203,7 @@ fn do_chapter_select(
                 .filter_map(|x| {
                     let ch = chapters_entry
                         .iter()
-                        .find(|&&ch| ch.uuid == x.name)
+                        .find(|&&ch| ch.uuid() == x.name)
                         .cloned();
 
                     ch.cloned()
@@ -232,21 +236,21 @@ fn select_quality_url(
     hires_available: bool,
 ) -> anyhow::Result<String> {
     if hires_available && quality == CLIDownloadQuality::Highest {
-        RBClient::modify_url_for_highres(&source[0].url).map_err(|e| anyhow::anyhow!(e))
+        RBClient::modify_url_for_highres(source[0].url()).map_err(|e| anyhow::anyhow!(e))
     } else {
         // Source is reverse sorted from highest to lowest quality
         match quality {
             CLIDownloadQuality::Highest | CLIDownloadQuality::High => {
                 // Get the highest quality image
                 match source.first() {
-                    Some(first_src) => Ok(first_src.url.clone()),
+                    Some(first_src) => Ok(first_src.url().to_string()),
                     None => Err(anyhow::anyhow!("No image source available for download")),
                 }
             }
             CLIDownloadQuality::Lowest => {
                 // Get the lowest quality image
                 match source.last() {
-                    Some(last_src) => Ok(last_src.url.clone()),
+                    Some(last_src) => Ok(last_src.url().to_string()),
                     None => Err(anyhow::anyhow!("No image source available for download")),
                 }
             }
@@ -256,11 +260,11 @@ fn select_quality_url(
                     // Get the middle quality image
                     let idx = source.len() / 2;
                     match source.get(idx) {
-                        Some(mid_src) => Ok(mid_src.url.clone()),
+                        Some(mid_src) => Ok(mid_src.url().to_string()),
                         None => {
                             // get the highest quality image
                             match source.first() {
-                                Some(first_src) => Ok(first_src.url.clone()),
+                                Some(first_src) => Ok(first_src.url().to_string()),
                                 None => Err(anyhow::anyhow!("Tried to get middle quality {idx} but no image source available for download")),
                             }
                         }
@@ -268,7 +272,7 @@ fn select_quality_url(
                 } else {
                     // Get the highest quality image
                     match source.first() {
-                        Some(first_src) => Ok(first_src.url.clone()),
+                        Some(first_src) => Ok(first_src.url().to_string()),
                         None => Err(anyhow::anyhow!("No image source available for download")),
                     }
                 }
@@ -289,8 +293,8 @@ async fn rbean_actual_downloader(
     let img_dl_path = image_dir.join(image_fn.clone());
 
     let mut img_source = match dl_config.format {
-        CLIDownloadFormat::Jpeg => node.page.image.jpg.clone(),
-        CLIDownloadFormat::Webp => node.page.image.webp.clone(),
+        CLIDownloadFormat::Jpeg => node.page.image().jpg().to_vec(),
+        CLIDownloadFormat::Webp => node.page.image().webp().to_vec(),
     };
 
     img_source.sort();
@@ -360,7 +364,7 @@ pub(crate) async fn rbean_download(
 
     console.info(cformat!(
         "Fetching chapters for <magenta,bold>{}</>...",
-        result.title
+        result.title()
     ));
 
     let chapter_meta = client.get_chapter_list(uuid).await;
@@ -374,9 +378,9 @@ pub(crate) async fn rbean_download(
     save_session_config(client, account);
 
     let chapters: Vec<&Chapter> = chapter_meta
-        .chapters
+        .chapters()
         .iter()
-        .filter(|&ch| ch.published.is_some())
+        .filter(|&ch| ch.published().is_some())
         .collect();
 
     if chapters.is_empty() {
@@ -392,11 +396,14 @@ pub(crate) async fn rbean_download(
 
     let download_chapters: Vec<&Chapter> = selected_chapters
         .iter()
-        .filter(|&ch| dl_config.chapter_ids.is_empty() || dl_config.chapter_ids.contains(&ch.uuid))
-        .filter(|&ch| ch.published.is_some() && !ch.upcoming)
+        .filter(|&ch| {
+            dl_config.chapter_ids.is_empty()
+                || dl_config.chapter_ids.contains(&ch.uuid().to_string())
+        })
+        .filter(|&ch| ch.published().is_some() && !ch.upcoming())
         .filter(|&ch| {
             // Download chapter if it's free or user is premium
-            ch.free_published.is_some() || acc_info.is_premium
+            ch.free_published().is_some() || acc_info.is_premium()
         })
         .collect();
 
@@ -405,8 +412,8 @@ pub(crate) async fn rbean_download(
         return 1;
     }
 
-    let title_dir = get_output_directory(&output_dir, result.uuid.clone(), None, true);
-    let dump_info = create_chapters_info(&result, chapter_meta.chapters);
+    let title_dir = get_output_directory(&output_dir, result.uuid().to_string(), None, true);
+    let dump_info = create_chapters_info(&result, chapter_meta.chapters());
 
     let title_dump_path = title_dir.join("_info.json");
     dump_info
@@ -417,12 +424,12 @@ pub(crate) async fn rbean_download(
         console.info(cformat!(
             "  Downloading chapter <m,s>{}</> ({})...",
             chapter.formatted_title(),
-            chapter.uuid
+            chapter.uuid()
         ));
 
         let image_dir = get_output_directory(
             &output_dir,
-            result.uuid.clone(),
+            result.uuid().to_string(),
             Some(chapter.formatted_title()),
             false,
         );
@@ -432,7 +439,7 @@ pub(crate) async fn rbean_download(
             CLIDownloadFormat::Webp => "webp",
         };
 
-        let view_req = client.get_chapter_viewer(&chapter.uuid).await;
+        let view_req = client.get_chapter_viewer(chapter.uuid()).await;
 
         if let Err(e) = view_req {
             console.error(cformat!(
@@ -447,11 +454,11 @@ pub(crate) async fn rbean_download(
         save_session_config(client, account);
 
         if let Some(count) = check_downloaded_image_count(&image_dir, image_ext) {
-            if count >= view_req.data.pages.len() {
+            if count >= view_req.data().pages().len() {
                 console.warn(cformat!(
                     "   Chapter <m,s>{}</> (<s>{}</>) has been downloaded, skipping",
                     chapter.formatted_title(),
-                    chapter.uuid
+                    chapter.uuid()
                 ));
                 continue;
             }
@@ -460,16 +467,16 @@ pub(crate) async fn rbean_download(
         // create chapter dir
         std::fs::create_dir_all(&image_dir).unwrap();
 
-        let total_img_count = view_req.data.pages.len() as u64;
+        let total_img_count = view_req.data().pages().len() as u64;
 
-        let pages_data = view_req.data.pages.clone();
+        let pages_data = view_req.data().pages();
 
         // Test if 2000x3000 is available when highest quality is selected
         let hires_available = match dl_config.quality {
             CLIDownloadQuality::Highest => {
                 let img_source = match dl_config.format {
-                    CLIDownloadFormat::Jpeg => pages_data[0].image.jpg.clone(),
-                    CLIDownloadFormat::Webp => pages_data[0].image.webp.clone(),
+                    CLIDownloadFormat::Jpeg => pages_data[0].image().jpg(),
+                    CLIDownloadFormat::Webp => pages_data[0].image().webp(),
                 };
                 let first_image = img_source.first().unwrap();
                 console.info(cformat!(
@@ -477,7 +484,7 @@ pub(crate) async fn rbean_download(
                     chapter.formatted_title()
                 ));
                 let test_hires = client
-                    .test_high_res(&first_image.url)
+                    .test_high_res(first_image.url())
                     .await
                     .unwrap_or(false);
 

--- a/tosho/src/impl/rbean/favorites.rs
+++ b/tosho/src/impl/rbean/favorites.rs
@@ -27,15 +27,18 @@ pub(crate) async fn rbean_read_list(
             console.info(cformat!("Reading list for <m,s>{}</>", account.id));
 
             for result in results.iter() {
-                do_print_single_information(&result.manga, 0, false, None);
+                let manga = result.manga();
+                do_print_single_information(manga, 0, false, None);
 
-                if let Some(chapter) = &result.chapter {
+                if let Some(chapter) = result.chapter() {
                     let linked_ch = format!(
                         "https://{}/series/{}/read/{}",
-                        &*BASE_HOST, result.manga.slug, chapter.uuid
+                        &*BASE_HOST,
+                        manga.slug(),
+                        chapter.uuid()
                     );
 
-                    let linked_url = linkify!(linked_ch, &format!("Chapter {}", chapter.name));
+                    let linked_url = linkify!(linked_ch, &format!("Chapter {}", chapter.name()));
 
                     console.info(cformat!("   <s>{}:</> {}", linked_url, linked_ch));
                 }

--- a/tosho/src/impl/rbean/manga.rs
+++ b/tosho/src/impl/rbean/manga.rs
@@ -82,17 +82,17 @@ pub(crate) async fn rbean_search(
         Ok(results) => {
             super::common::save_session_config(client, account);
 
-            if results.results.is_empty() {
+            if results.results().is_empty() {
                 console.warn("No results found!");
                 return 0;
             }
 
             console.info(cformat!(
                 "Search results (<magenta,bold>{}</> results):",
-                results.results.len()
+                results.results().len()
             ));
 
-            do_print_search_information(&results.results, false, None);
+            do_print_search_information(results.results(), false, None);
 
             0
         }
@@ -152,7 +152,7 @@ pub(crate) async fn rbean_title_info(
     if show_chapters {
         console.info(cformat!(
             "Fetching chapters for <magenta,bold>{}</>...",
-            result.title
+            result.title()
         ));
 
         let fetch_chapters = client.get_chapter_list(uuid).await;
@@ -166,23 +166,27 @@ pub(crate) async fn rbean_title_info(
         save_session_config(client, account);
     }
 
-    let manga_url = format!("https://{}/series/{}", &*BASE_HOST, result.slug);
-    let linked = linkify!(&manga_url, &result.title);
+    let manga_url = format!("https://{}/series/{}", &*BASE_HOST, result.slug());
+    let linked = linkify!(&manga_url, result.title());
 
     console.info(cformat!(
         "Title information for <magenta,bold>{}</>:",
         linked
     ));
 
-    let creators: Vec<String> = result.creators.iter().map(|c| c.name.clone()).collect();
+    let creators: Vec<String> = result
+        .creators()
+        .iter()
+        .map(|c| c.name().to_string())
+        .collect();
 
     console.info(cformat!("  <s>Authors</>: {}", format_named_vec(creators)));
     let genres: Vec<String> = result
-        .genres
+        .genres()
         .iter()
         .map(|g| {
-            let genre_url = format!("https://{}/series?tags={}", &*BASE_HOST, g.slug);
-            linkify!(&genre_url, &g.name)
+            let genre_url = format!("https://{}/series?tags={}", &*BASE_HOST, g.slug());
+            linkify!(&genre_url, g.name())
         })
         .collect();
     if !genres.is_empty() {
@@ -191,93 +195,94 @@ pub(crate) async fn rbean_title_info(
 
     let publish_url = format!(
         "https://{}/publishers/{}",
-        &*BASE_HOST, result.publisher.slug
+        &*BASE_HOST,
+        result.publisher().slug()
     );
-    let linked_pub = linkify!(&publish_url, &result.publisher.name);
+    let linked_pub = linkify!(&publish_url, result.publisher().name());
     console.info(cformat!("  <s>Publisher</>: {}", linked_pub));
 
-    if let Some(release_schedule) = &result.release_schedule {
+    if let Some(release_schedule) = result.release_schedule() {
         console.info(cformat!("  <s>Release schedule</>: {}", release_schedule));
     }
 
     console.info(cformat!("  <s>Summary</>"));
-    console.info(format!("   {}", result.description));
+    console.info(format!("   {}", result.description()));
 
     println!();
 
-    console.info(cformat!("  <s>Chapters</>: {} chapters", result.chapters));
+    console.info(cformat!("  <s>Chapters</>: {} chapters", result.chapters()));
 
     if let Some(chapter_meta) = chapter_meta {
         let mut index_to_separator = HashMap::new();
-        for separator in chapter_meta.separators.iter() {
+        for separator in chapter_meta.separators().iter() {
             match separator {
                 Separator::AlaCarteNotice(purchase) => {
-                    index_to_separator.insert(purchase.index, separator.clone());
+                    index_to_separator.insert(purchase.index(), separator.clone());
                 }
                 Separator::ChapterGap(volume) => {
-                    index_to_separator.insert(volume.index, separator.clone());
+                    index_to_separator.insert(volume.index(), separator.clone());
                 }
                 Separator::PremiumNotice(volume) => {
-                    index_to_separator.insert(volume.index, separator.clone());
+                    index_to_separator.insert(volume.index(), separator.clone());
                 }
                 _ => {}
             }
         }
 
-        let mut ignored_uuid = vec![];
-        for (idx, chapter) in chapter_meta.chapters.iter().enumerate() {
+        let mut ignored_uuid: Vec<&str> = vec![];
+        for (idx, chapter) in chapter_meta.chapters().iter().enumerate() {
             let separator = index_to_separator.remove(&(idx as i32));
             if let Some(ref separator) = separator {
                 match &separator {
                     Separator::PremiumNotice(sep) => {
                         console.info(cformat!(
                             "    <m>Unlock the first {} chapters by <s>upgrading to Premium</></>",
-                            sep.data.count
+                            sep.data().count()
                         ));
                     }
                     Separator::ChapterGap(sep) => {
                         console.info(cformat!(
                             "    <b>Chapters <s>{}-{}</> is currently on backlog!</>",
-                            sep.data.range.start,
-                            sep.data.range.end
+                            sep.data().range().start(),
+                            sep.data().range().end()
                         ));
                     }
                     _ => {}
                 }
             }
 
-            if ignored_uuid.contains(&chapter.uuid) {
+            if ignored_uuid.contains(&chapter.uuid()) {
                 continue;
             }
 
             let ch_title = chapter.formatted_title();
-            let ch_url = format!("{}/read/{}", manga_url, chapter.uuid);
+            let ch_url = format!("{}/read/{}", manga_url, chapter.uuid());
 
             let linked_ch = linkify!(&ch_url, &ch_title);
-            let mut banner_title = cformat!("    <s>{}</> ({})", linked_ch, chapter.uuid);
+            let mut banner_title = cformat!("    <s>{}</> ({})", linked_ch, chapter.uuid());
 
-            if !chapter.premium {
+            if !chapter.premium() {
                 banner_title.push_str(&cformat!(" <green,bold>[<rev>FREE</>]</>"));
             }
 
-            if chapter.new {
+            if chapter.new() {
                 banner_title.push_str(&cformat!(" <yellow,bold>[<rev>NEW</>]</>"));
             }
 
             if let Some(Separator::AlaCarteNotice(volume)) = separator {
-                let total_chapters_next = volume.data.count;
+                let total_chapters_next = volume.data().count();
                 let mut volume_chapters: HashMap<String, Vec<String>> = HashMap::new();
 
                 for ch in chapter_meta
-                    .chapters
+                    .chapters()
                     .iter()
                     .skip(idx + 1)
                     .take(total_chapters_next as usize)
                 {
                     // insert ch.volume_uuid -> [ch.chapter]
-                    let volume_uuid = ch.volume_uuid.clone().unwrap_or_else(|| "".to_string());
-                    let ch_num = ch.chapter.clone();
-                    ignored_uuid.push(ch.uuid.clone());
+                    let volume_uuid = ch.volume_uuid().unwrap_or("").to_string();
+                    let ch_num = ch.chapter().to_string();
+                    ignored_uuid.push(ch.uuid());
                     volume_chapters.entry(volume_uuid).or_default().push(ch_num);
                 }
 
@@ -287,14 +292,14 @@ pub(crate) async fn rbean_title_info(
 
                 // we have an ordering of volumes from chapter_meta.volume_order which is a Vec<String>
                 let mut sorted_volume_chapters = vec![];
-                for volume_uuid in chapter_meta.volume_order.iter() {
+                for volume_uuid in chapter_meta.volume_order().iter() {
                     if let Some(chapters) = volume_chapters.get(volume_uuid) {
                         sorted_volume_chapters.push((volume_uuid, chapters.clone()));
                     }
                 }
 
                 for (volume_uuid, chapters) in sorted_volume_chapters {
-                    let volume = chapter_meta.volumes.get(volume_uuid);
+                    let volume = chapter_meta.volumes().get(volume_uuid);
 
                     if let Some(volume) = volume {
                         let first_last = format!(
@@ -304,15 +309,15 @@ pub(crate) async fn rbean_title_info(
                         );
 
                         let vol_url_link = format!("{}/volumes", manga_url);
-                        let vol_url_linked = linkify!(&vol_url_link, &volume.short_title);
+                        let vol_url_linked = linkify!(&vol_url_link, volume.short_title());
 
                         console.info(cformat!("     <s>{}</>: {}", vol_url_linked, first_last));
                     }
                 }
-            } else if chapter.upcoming {
+            } else if chapter.upcoming() {
                 let mut merged_string = ch_title.to_string();
 
-                if let Some(publish_at) = chapter.published {
+                if let Some(publish_at) = chapter.published() {
                     let publish_at = publish_at.format("%b %d, %Y").to_string();
                     merged_string.push_str(&cformat!(" <s>({})</>", publish_at));
                 }
@@ -320,7 +325,7 @@ pub(crate) async fn rbean_title_info(
                 console.info(cformat!("    <s,m>Upcoming</>: {}", merged_string));
             } else {
                 console.info(&banner_title);
-                if let Some(publish_at) = chapter.published {
+                if let Some(publish_at) = chapter.published() {
                     let publish_at = publish_at.format("%b %d, %Y").to_string();
                     console.info(cformat!("     <s>Published</>: {}", publish_at));
                 }
@@ -330,7 +335,7 @@ pub(crate) async fn rbean_title_info(
         println!();
     }
 
-    if let Some(credits) = &result.credits {
+    if let Some(credits) = result.credits() {
         let split_credits = credits.split('\n').collect::<Vec<&str>>();
         if split_credits.len() > 1 {
             console.info(cformat!("  <s>Credits</>:"));

--- a/tosho/src/impl/rbean/rankings.rs
+++ b/tosho/src/impl/rbean/rankings.rs
@@ -30,56 +30,57 @@ pub(crate) async fn rbean_home_page(
             save_session_config(client, account);
             console.info(cformat!("Home page for <m,s>{}</>", account.id));
 
-            if let Some(hero_manga) = results.hero.manga {
-                let manga_url = format!("https://{}/series/{}", &*BASE_HOST, hero_manga.slug);
-                let linked_url = linkify!(manga_url, &hero_manga.title);
+            if let Some(hero_manga) = results.hero().manga() {
+                let manga_url = format!("https://{}/series/{}", &*BASE_HOST, hero_manga.slug());
+                let linked_url = linkify!(manga_url, hero_manga.title());
                 console.info(cformat!(">> <m,s>{}</> <<", linked_url));
                 console.info(&manga_url);
-                if !results.hero.title.is_empty() {
-                    console.info(cformat!("<m,s>{}</>", results.hero.title));
+                if !results.hero().title().is_empty() {
+                    console.info(cformat!("<m,s>{}</>", results.hero().title()));
                 }
-                if !results.hero.subtitle.is_empty() {
-                    console.info(cformat!(" <s>{}</>", results.hero.subtitle));
+                if !results.hero().subtitle().is_empty() {
+                    console.info(cformat!(" <s>{}</>", results.hero().subtitle()));
                 }
-                if !results.hero.alt_text.is_empty() {
-                    console.info(format!(" {}", results.hero.alt_text));
+                if !results.hero().alt_text().is_empty() {
+                    console.info(format!(" {}", results.hero().alt_text()));
                 }
 
                 println!();
             }
 
-            if !results.featured.is_empty() {
+            if !results.featured().is_empty() {
                 console.info(cformat!("<s>Featured manga:</>"));
             }
 
-            for featured in results.featured.iter() {
-                let manga_url = format!("https://{}/series/{}", &*BASE_HOST, featured.manga.slug);
-                let linked_url = linkify!(manga_url, &featured.manga.title);
+            for featured in results.featured().iter() {
+                let manga_url =
+                    format!("https://{}/series/{}", &*BASE_HOST, featured.manga().slug());
+                let linked_url = linkify!(manga_url, &featured.manga().title());
                 console.info(cformat!(
                     " <m,s>{}</>: <s>{}</>",
-                    featured.title,
+                    featured.title(),
                     linked_url
                 ));
-                console.info(format!("  {}", featured.description));
+                console.info(format!("  {}", featured.description()));
                 console.info(format!("   {}", manga_url));
             }
 
             loop {
                 let rank_choices = results
-                    .carousels
+                    .carousels()
                     .iter()
                     .map(|r| match r {
                         Carousel::ContinueReading(c) => ConsoleChoice {
-                            name: c.title.clone(),
-                            value: c.title.clone(),
+                            name: c.title().to_string(),
+                            value: c.title().to_string(),
                         },
                         Carousel::MangaList(c) => ConsoleChoice {
-                            name: c.title.clone(),
-                            value: c.title.clone(),
+                            name: c.title().to_string(),
+                            value: c.title().to_string(),
                         },
                         Carousel::MangaWithChapters(c) => ConsoleChoice {
-                            name: c.title.clone(),
-                            value: c.title.clone(),
+                            name: c.title().to_string(),
+                            value: c.title().to_string(),
                         },
                     })
                     .collect::<Vec<ConsoleChoice>>();
@@ -93,27 +94,27 @@ pub(crate) async fn rbean_home_page(
                     }
                     Some(select) => {
                         let ranking = results
-                            .carousels
+                            .carousels()
                             .iter()
                             .find(|&r| match r {
-                                Carousel::ContinueReading(c) => c.title == select.name,
-                                Carousel::MangaList(c) => c.title == select.name,
-                                Carousel::MangaWithChapters(c) => c.title == select.name,
+                                Carousel::ContinueReading(c) => c.title() == select.name,
+                                Carousel::MangaList(c) => c.title() == select.name,
+                                Carousel::MangaWithChapters(c) => c.title() == select.name,
                             })
                             .unwrap();
 
                         let title = match ranking {
-                            Carousel::ContinueReading(c) => c.title.clone(),
-                            Carousel::MangaList(c) => c.title.clone(),
-                            Carousel::MangaWithChapters(c) => c.title.clone(),
+                            Carousel::ContinueReading(c) => c.title().to_string(),
+                            Carousel::MangaList(c) => c.title().to_string(),
+                            Carousel::MangaWithChapters(c) => c.title().to_string(),
                         };
 
                         let manga_list: Vec<MangaNode> = match ranking {
                             Carousel::ContinueReading(c) => {
-                                c.items.iter().map(|i| i.manga.clone()).collect()
+                                c.items().iter().map(|i| i.manga().clone()).collect()
                             }
-                            Carousel::MangaList(c) => c.items.to_vec(),
-                            Carousel::MangaWithChapters(c) => c.items.to_vec(),
+                            Carousel::MangaList(c) => c.items().to_vec(),
+                            Carousel::MangaWithChapters(c) => c.items().to_vec(),
                         };
 
                         console.info(cformat!(

--- a/tosho/src/impl/sjv/accounts.rs
+++ b/tosho/src/impl/sjv/accounts.rs
@@ -68,14 +68,14 @@ pub async fn sjv_account_login(
 
             console.info(cformat!(
                 "Authenticated as <m,s>{}</> ({})",
-                account.username,
+                account.username(),
                 email,
             ));
 
             let new_config: Config = config.into();
             let new_config = new_config
                 .with_email(&email)
-                .with_username(&account.username)
+                .with_username(account.username())
                 .with_mode(mode);
 
             let new_config = if let Some(old_id) = old_id {
@@ -168,9 +168,9 @@ pub(crate) async fn sjv_account_subscriptions(
                 account.id
             ));
 
-            let subs_data = &subs_resp.subscriptions;
+            let subs_data = subs_resp.subscriptions();
 
-            let sj_end_date = match subs_data.sj_valid_to {
+            let sj_end_date = match subs_data.sj_valid_to() {
                 Some(date) => {
                     if let Some(unix_parse) = unix_timestamp_to_string(date) {
                         unix_parse
@@ -180,7 +180,7 @@ pub(crate) async fn sjv_account_subscriptions(
                 }
                 None => "N/A".to_string(),
             };
-            let vm_end_date = match subs_data.vm_valid_to {
+            let vm_end_date = match subs_data.vm_valid_to() {
                 Some(date) => {
                     if let Some(unix_parse) = unix_timestamp_to_string(date) {
                         unix_parse

--- a/tosho/src/impl/sjv/config.rs
+++ b/tosho/src/impl/sjv/config.rs
@@ -135,7 +135,7 @@ pub struct Config {
 impl From<SJConfig> for Config {
     fn from(value: SJConfig) -> Self {
         let new_uuid = uuid::Uuid::new_v4().to_string();
-        let platform = match value.platform {
+        let platform = match value.platform() {
             SJPlatform::Android => DeviceType::Android,
             SJPlatform::Apple => DeviceType::Apple,
             SJPlatform::Web => DeviceType::Web,
@@ -144,9 +144,9 @@ impl From<SJConfig> for Config {
             id: new_uuid.clone(),
             email: format!("{}@sjv.xyz", new_uuid),
             username: "sjv_temp".to_string(),
-            user_id: value.user_id,
-            token: value.token,
-            instance: value.instance,
+            user_id: value.user_id(),
+            token: value.token().to_string(),
+            instance: value.instance().to_string(),
             r#type: platform as i32,
             mode: SJDeviceMode::SJ as i32,
         }
@@ -155,16 +155,16 @@ impl From<SJConfig> for Config {
 
 impl From<Config> for SJConfig {
     fn from(value: Config) -> Self {
-        Self {
-            user_id: value.user_id,
-            token: value.token.clone(),
-            instance: value.instance.clone(),
-            platform: match value.r#type() {
+        Self::new(
+            value.user_id,
+            &value.token,
+            &value.instance,
+            match value.r#type() {
                 DeviceType::Android => SJPlatform::Android,
                 DeviceType::Apple => SJPlatform::Apple,
                 DeviceType::Web => SJPlatform::Web,
             },
-        }
+        )
     }
 }
 

--- a/tosho/src/impl/sjv/download.rs
+++ b/tosho/src/impl/sjv/download.rs
@@ -40,10 +40,8 @@ pub(crate) struct SJDownloadCliConfig {
 }
 
 fn create_chapters_info(title: &MangaDetail, chapters: &[MangaChapterDetail]) -> MangaDetailDump {
-    let mut dumped_chapters: Vec<ChapterDetailDump> = vec![];
-    for chapter in chapters {
-        dumped_chapters.push(ChapterDetailDump::from(chapter));
-    }
+    let dumped_chapters: Vec<ChapterDetailDump> =
+        chapters.iter().map(ChapterDetailDump::from).collect();
 
     MangaDetailDump::new(
         title.title().to_string(),

--- a/tosho/src/impl/sjv/manga.rs
+++ b/tosho/src/impl/sjv/manga.rs
@@ -77,9 +77,9 @@ pub(crate) async fn sjv_title_info(
 
             let title = results.series.iter().find(|x| {
                 if let NumberOrString::Number(n) = title_or_slug {
-                    x.id == n as u32
+                    x.id() == n as u32
                 } else {
-                    x.slug == title_or_slug.to_string()
+                    x.slug() == title_or_slug.to_string()
                 }
             });
 
@@ -92,12 +92,12 @@ pub(crate) async fn sjv_title_info(
 
             let mut chapters_lists = vec![];
             let mut chapter_messages: HashMap<String, ChapterMessage> = HashMap::new();
-            if show_chapters && result.total_chapters > 0 {
+            if show_chapters && result.total_chapters() > 0 {
                 console.info(cformat!(
                     "Fetching chapters for <magenta,bold>{}</>...",
-                    result.title
+                    result.title()
                 ));
-                let chapters_info = client.get_chapters(result.id).await;
+                let chapters_info = client.get_chapters(result.id()).await;
 
                 match chapters_info {
                     Err(_) => {
@@ -109,18 +109,18 @@ pub(crate) async fn sjv_title_info(
                     Ok(series_response) => {
                         let mut chapters_info: Vec<tosho_sjv::models::MangaChapterDetail> =
                             series_response
-                                .chapters
+                                .chapters()
                                 .iter()
-                                .map(|ch| ch.chapter.clone())
+                                .map(|ch| ch.chapter().clone())
                                 .collect();
                         sort_chapters(&mut chapters_info, true);
                         chapters_lists.clone_from(&chapters_info);
 
-                        for message in series_response.notices {
+                        for message in series_response.notices() {
                             if message.is_active() {
                                 // format the ofsset into string (include the comma)
-                                let offset_str = format!("{:?}", message.offset);
-                                chapter_messages.insert(offset_str, message);
+                                let offset_str = format!("{:?}", message.offset());
+                                chapter_messages.insert(offset_str, message.clone());
                             }
                         }
                     }
@@ -130,29 +130,29 @@ pub(crate) async fn sjv_title_info(
             let manga_url = format!(
                 "https://{}/{}",
                 &*tosho_sjv::constants::BASE_HOST,
-                result.slug
+                result.slug()
             );
-            let linked = linkify!(&manga_url, &result.title);
+            let linked = linkify!(&manga_url, result.title());
             console.info(cformat!(
                 "Title information for <magenta,bold>{}</>",
                 linked,
             ));
 
-            if let Some(author) = &result.author {
+            if let Some(author) = result.author() {
                 console.info(cformat!("  <s>Author</>: {}", author));
             }
-            if result.imprint != MangaImprint::Undefined {
+            if result.imprint() != MangaImprint::Undefined {
                 console.info(cformat!(
                     "  <s>Imprint</>: {}",
-                    result.imprint.pretty_name()
+                    result.imprint().pretty_name()
                 ));
             }
 
-            console.info(cformat!("  <s>Rating</>: {}", result.rating.to_name()));
-            console.info(cformat!("  <s>Copyright</>: {}", result.copyright));
-            let synopsis = result.synopsis.replace("\r\n", "\n");
+            console.info(cformat!("  <s>Rating</>: {}", result.rating().to_name()));
+            console.info(cformat!("  <s>Copyright</>: {}", result.copyright()));
+            let synopsis = result.synopsis().replace("\r\n", "\n");
             console.info(cformat!("  <s>Summary</>"));
-            if let Some(tagline) = &result.tagline {
+            if let Some(tagline) = result.tagline() {
                 console.info(cformat!("   <blue>{}</>", tagline));
             }
             let synopsis = synopsis.trim();
@@ -166,36 +166,36 @@ pub(crate) async fn sjv_title_info(
             println!();
             console.info(cformat!(
                 "  <s>Chapters</>: {} chapters",
-                result.total_chapters
+                result.total_chapters()
             ));
-            if result.total_volumes > 0 {
+            if result.total_volumes() > 0 {
                 console.info(cformat!(
                     "   <s>Volumes</>: {} volumes",
-                    result.total_volumes
+                    result.total_volumes()
                 ));
             }
 
             if !chapters_lists.is_empty() {
                 for chapter in chapters_lists {
                     // Skip for now
-                    if chapter.chapter.is_none() {
+                    if chapter.chapter().is_none() {
                         continue;
                     }
 
                     // if chapter number is in offset, print the message
-                    let chapter_number = chapter.chapter.clone().unwrap_or_default();
-                    if let Some(message) = chapter_messages.get(&chapter_number) {
-                        console.info(cformat!("    <r!,strong>{}</>", message.message));
+                    let chapter_number = chapter.chapter().unwrap_or_default();
+                    if let Some(message) = chapter_messages.get(chapter_number) {
+                        console.info(cformat!("    <r!,strong>{}</>", message.message()));
                     }
 
-                    let episode_url = match chapter.subscription_type {
+                    let episode_url = match chapter.subscription_type() {
                         Some(tosho_sjv::models::SubscriptionType::SJ) => {
                             format!(
                                 "https://{}/{}/{}/chapter/{}?action=read",
                                 &*tosho_sjv::constants::BASE_HOST,
                                 &*EXPAND_SJ_NAME,
-                                result.slug,
-                                chapter.id
+                                result.slug(),
+                                chapter.id()
                             )
                         }
                         Some(tosho_sjv::models::SubscriptionType::VM) => {
@@ -203,24 +203,24 @@ pub(crate) async fn sjv_title_info(
                                 "https://{}/{}/{}/chapter/{}?action=read",
                                 &*tosho_sjv::constants::BASE_HOST,
                                 &*EXPAND_VM_NAME,
-                                result.slug,
-                                chapter.id
+                                result.slug(),
+                                chapter.id()
                             )
                         }
                         None => linked.clone(),
                     };
 
                     let ep_linked = linkify!(&episode_url, &chapter.pretty_title());
-                    let mut base_txt = cformat!("    <s>{}</> ({})", ep_linked, chapter.id);
+                    let mut base_txt = cformat!("    <s>{}</> ({})", ep_linked, chapter.id());
                     if chapter.is_available() {
                         base_txt =
                             cformat!("{} <g!,strong>[<rev>Free</rev>]</g!,strong>", base_txt);
                     }
                     console.info(&base_txt);
 
-                    let created_at = chapter.created_at.format("%b %d, %Y").to_string();
+                    let created_at = chapter.created_at().format("%b %d, %Y").to_string();
                     console.info(cformat!("     <s>Published</>: {}", created_at));
-                    if let Some(expiry_at) = chapter.expiry_at {
+                    if let Some(expiry_at) = chapter.expiry_at() {
                         let expiry_at =
                             unix_timestamp_to_string(expiry_at).unwrap_or("N/A".to_string());
                         console.info(cformat!("      <s>Expires</>: {}", expiry_at));

--- a/tosho_amap/README.md
+++ b/tosho_amap/README.md
@@ -15,12 +15,7 @@ use tosho_amap::{AMClient, AMConfig};
 
 #[tokio::main]
 async fn main() {
-    let config = AMConfig {
-        token: "123".to_string(),
-        identifier: "abcxyz".to_string(),
-        session_v2: "xyz987abc".to_string(),
-    };
-
+    let config = AMConfig::new("123", "abcxyz", "xyz987abc");
     let client = AMClient::new(config).unwrap();
 
     let manga = client.get_comic(48000051).await.unwrap();

--- a/tosho_amap/src/config.rs
+++ b/tosho_amap/src/config.rs
@@ -3,11 +3,7 @@
 //! ```rust
 //! use tosho_amap::AMConfig;
 //!
-//! let config = AMConfig {
-//!     token: "123".to_string(),
-//!     identifier: "abcxyz".to_string(),
-//!     session_v2: "xyz987abc".to_string(),
-//! };
+//! let config = AMConfig::new("123", "abcxyz", "xyz987abc");
 //! ```
 
 use std::sync::LazyLock;

--- a/tosho_amap/src/config.rs
+++ b/tosho_amap/src/config.rs
@@ -16,6 +16,7 @@ use base64::{engine::general_purpose, Engine as _};
 use reqwest::Url;
 use reqwest_cookie_store::{CookieStoreMutex, RawCookie};
 use tosho_common::{make_error, ToshoError};
+use tosho_macros::AutoGetter;
 
 use crate::constants::BASE_HOST;
 
@@ -30,14 +31,29 @@ pub static SESSION_COOKIE_NAME: LazyLock<String> = LazyLock::new(|| {
 });
 
 /// Represents the configuration for the client.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, AutoGetter)]
 pub struct AMConfig {
     /// The token of the account
-    pub token: String,
+    token: String,
     /// The identifier (guest ID) of the account, tied to token.
-    pub identifier: String,
+    identifier: String,
     /// The cookie of session_v2
-    pub session_v2: String,
+    session_v2: String,
+}
+
+impl AMConfig {
+    /// Create a new config instance of [`AMConfig`]
+    pub fn new(
+        token: impl Into<String>,
+        identifier: impl Into<String>,
+        session_v2: impl Into<String>,
+    ) -> Self {
+        Self {
+            token: token.into(),
+            identifier: identifier.into(),
+            session_v2: session_v2.into(),
+        }
+    }
 }
 
 impl TryFrom<AMConfig> for reqwest_cookie_store::CookieStore {

--- a/tosho_amap/src/constants.rs
+++ b/tosho_amap/src/constants.rs
@@ -167,9 +167,9 @@ pub(crate) static MASKED_LOGIN: LazyLock<String> = LazyLock::new(|| {
 /// Panics if the device type is invalid.
 ///
 /// # Examples
-/// ```
-/// use tosho_amap::constants::get_constants;
-///
+/// ```rust
+/// # use tosho_amap::constants::get_constants;
+/// #
 /// let _ = get_constants(1); // Android
 /// ```
 pub fn get_constants(device_type: u8) -> &'static Constants {

--- a/tosho_amap/src/helper.rs
+++ b/tosho_amap/src/helper.rs
@@ -37,10 +37,10 @@ impl ComicPurchase {
 
         let price = episode.price;
 
-        let bonus = account.bonus;
-        let purchased = account.purchased;
-        let premium = account.premium;
-        let point = account.point;
+        let bonus = account.bonus();
+        let purchased = account.purchased();
+        let premium = account.premium();
+        let point = account.point();
 
         let is_free_daily = episode.is_free_daily;
 

--- a/tosho_amap/src/helper.rs
+++ b/tosho_amap/src/helper.rs
@@ -32,17 +32,17 @@ impl ComicPurchase {
         episode: &ComicEpisodeInfoNode,
         account: &mut IAPInfo,
     ) -> Option<Self> {
-        let id = episode.id;
-        let rental_term = comic.rental_term.clone();
+        let id = episode.id();
+        let rental_term = comic.rental_term().map(|e| e.to_string());
 
-        let price = episode.price;
+        let price = episode.price();
 
         let bonus = account.bonus();
         let purchased = account.purchased();
         let premium = account.premium();
         let point = account.point();
 
-        let is_free_daily = episode.is_free_daily;
+        let is_free_daily = episode.is_free_daily();
 
         if is_free_daily {
             return Some(Self {

--- a/tosho_amap/src/lib.rs
+++ b/tosho_amap/src/lib.rs
@@ -177,7 +177,11 @@ impl AMClient {
             )
             .await?;
 
-        results.result.body.ok_or_else(ToshoParseError::empty)
+        results
+            .result()
+            .body()
+            .ok_or_else(ToshoParseError::empty)
+            .cloned()
     }
 
     /// Get a single comic information by ID.
@@ -204,7 +208,11 @@ impl AMClient {
             )
             .await?;
 
-        results.result.body.ok_or_else(ToshoParseError::empty)
+        results
+            .result()
+            .body()
+            .ok_or_else(ToshoParseError::empty)
+            .cloned()
     }
 
     /// Get reader/viewer for an episode.
@@ -268,7 +276,11 @@ impl AMClient {
             )
             .await?;
 
-        results.result.body.ok_or_else(ToshoParseError::empty)
+        results
+            .result()
+            .body()
+            .ok_or_else(ToshoParseError::empty)
+            .cloned()
     }
 
     /// Get the account for the current session.
@@ -284,7 +296,11 @@ impl AMClient {
             )
             .await?;
 
-        results.result.body.ok_or_else(ToshoParseError::empty)
+        results
+            .result()
+            .body()
+            .ok_or_else(ToshoParseError::empty)
+            .cloned()
     }
 
     /// Get account favorites.
@@ -297,7 +313,11 @@ impl AMClient {
             )
             .await?;
 
-        results.result.body.ok_or_else(ToshoParseError::empty)
+        results
+            .result()
+            .body()
+            .ok_or_else(ToshoParseError::empty)
+            .cloned()
     }
 
     /// Search for comics.
@@ -352,7 +372,11 @@ impl AMClient {
             )
             .await?;
 
-        results.result.body.ok_or_else(ToshoParseError::empty)
+        results
+            .result()
+            .body()
+            .ok_or_else(ToshoParseError::empty)
+            .cloned()
     }
 
     /// Get home discovery.
@@ -361,7 +385,11 @@ impl AMClient {
             .request::<ComicDiscovery>(reqwest::Method::POST, "/manga/discover.json", None)
             .await?;
 
-        results.result.body.ok_or_else(ToshoParseError::empty)
+        results
+            .result()
+            .body()
+            .ok_or_else(ToshoParseError::empty)
+            .cloned()
     }
 
     /// Stream download the image from the given URL.
@@ -465,7 +493,7 @@ impl AMClient {
         let results =
             parse_json_response_failable::<APIResult<models::IAPRemainder>, BasicWrapStatus>(req)
                 .await?;
-        let result = results.clone().result.body.ok_or_else(|| {
+        let result = results.result().body().ok_or_else(|| {
             make_error!(
                 "Failed to get remainder, got empty response: {:#?}",
                 results
@@ -490,7 +518,7 @@ impl AMClient {
 
         let temp_config = AMConfig {
             token: secret_token.clone(),
-            identifier: result.info.guest_id,
+            identifier: result.info().guest_id().to_string(),
             session_v2: "".to_string(),
         };
 
@@ -505,10 +533,10 @@ impl AMClient {
             .await?;
 
         let results = parse_json_response::<APIResult<models::LoginResult>>(req).await?;
-        let result =
-            results.clone().result.body.ok_or_else(|| {
-                ToshoAuthError::InvalidCredentials("Got empty response".to_string())
-            })?;
+        let result = results
+            .result()
+            .body()
+            .ok_or_else(|| ToshoAuthError::InvalidCredentials("Got empty response".to_string()))?;
 
         // final step: get session_v2
         let mut json_body_session = HashMap::new();
@@ -525,7 +553,7 @@ impl AMClient {
 
         let temp_config = AMConfig {
             token: secret_token.clone(),
-            identifier: result.info.guest_id.clone(),
+            identifier: result.info().guest_id().to_string(),
             session_v2: "".to_string(),
         };
 
@@ -559,7 +587,7 @@ impl AMClient {
 
         Ok(AMConfig {
             token: secret_token,
-            identifier: result.info.guest_id,
+            identifier: result.info().guest_id().to_string(),
             session_v2,
         })
     }

--- a/tosho_amap/src/lib.rs
+++ b/tosho_amap/src/lib.rs
@@ -1,3 +1,9 @@
+#![warn(
+    missing_docs,
+    clippy::empty_docs,
+    rustdoc::broken_intra_doc_links,
+    clippy::missing_docs_in_private_items
+)]
 #![doc = include_str!("../README.md")]
 
 use std::{collections::HashMap, sync::MutexGuard};

--- a/tosho_amap/src/lib.rs
+++ b/tosho_amap/src/lib.rs
@@ -328,7 +328,7 @@ impl AMClient {
     /// * `limit` - The limit of results per page. (default to 30)
     pub async fn search(
         &self,
-        query: &str,
+        query: impl Into<String>,
         status: Option<ComicStatus>,
         tag_id: Option<u64>,
         page: Option<u64>,
@@ -339,7 +339,7 @@ impl AMClient {
         let mut conditions = serde_json::Map::new();
         conditions.insert(
             "free_word".to_string(),
-            serde_json::Value::String(query.to_string()),
+            serde_json::Value::String(query.into()),
         );
         conditions.insert(
             "tag_id".to_string(),
@@ -399,7 +399,7 @@ impl AMClient {
     /// * `writer` - The writer to write the image to.
     pub async fn stream_download(
         &self,
-        url: &str,
+        url: impl Into<String>,
         mut writer: impl tokio::io::AsyncWrite + Unpin,
     ) -> ToshoResult<()> {
         let mut headers = make_header(&self.config, self.constants)?;
@@ -411,6 +411,7 @@ impl AMClient {
             "User-Agent",
             reqwest::header::HeaderValue::from_static(&self.constants.image_ua),
         );
+        let url: String = url.into();
 
         let res = self.inner.get(url).headers(headers).send().await?;
 
@@ -433,7 +434,10 @@ impl AMClient {
     /// # Arguments
     /// * `email` - The email of the user.
     /// * `password` - The password of the user.
-    pub async fn login(email: &str, password: &str) -> ToshoResult<AMConfig> {
+    pub async fn login(
+        email: impl Into<String>,
+        password: impl Into<String>,
+    ) -> ToshoResult<AMConfig> {
         let cookie_store = CookieStoreMutex::default();
         let cookie_store = std::sync::Arc::new(cookie_store);
 
@@ -502,13 +506,10 @@ impl AMClient {
 
         // Step 2: Perform login
         let mut json_body_login = HashMap::new();
-        json_body_login.insert(
-            "email".to_string(),
-            serde_json::Value::String(email.to_string()),
-        );
+        json_body_login.insert("email".to_string(), serde_json::Value::String(email.into()));
         json_body_login.insert(
             "citi_pass".to_string(),
-            serde_json::Value::String(password.to_string()),
+            serde_json::Value::String(password.into()),
         );
         json_body_login.insert(
             "iap_token".to_string(),

--- a/tosho_amap/src/lib.rs
+++ b/tosho_amap/src/lib.rs
@@ -1,9 +1,4 @@
-#![warn(
-    missing_docs,
-    clippy::empty_docs,
-    rustdoc::broken_intra_doc_links,
-    clippy::missing_docs_in_private_items
-)]
+#![warn(missing_docs, clippy::empty_docs, rustdoc::broken_intra_doc_links)]
 #![doc = include_str!("../README.md")]
 
 use std::{collections::HashMap, sync::MutexGuard};

--- a/tosho_amap/src/models/accounts.rs
+++ b/tosho_amap/src/models/accounts.rs
@@ -22,12 +22,16 @@ pub struct IAPInfo {
     new_bonus: u64,
     /// The request payload
     payload: String,
+    /// The next point reset in second
     #[serde(rename = "next_pp_second")]
     next_point_second: u64,
+    /// The next point in UNIX timestamp
     #[serde(rename = "next_pp_time")]
     next_point_time: u64,
+    /// The next point
     #[serde(rename = "next_pp")]
     next_point: u64,
+    #[allow(clippy::missing_docs_in_private_items)]
     available_wall: bool,
     /// The account identifier for the user
     ///

--- a/tosho_amap/src/models/accounts.rs
+++ b/tosho_amap/src/models/accounts.rs
@@ -3,35 +3,36 @@
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
 use serde::{Deserialize, Serialize};
+use tosho_macros::AutoGetter;
 
 /// User purchase information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct IAPInfo {
     /// Bonus ticket
-    pub bonus: u64,
+    bonus: u64,
     /// Purchased ticket
     #[serde(rename = "product")]
-    pub purchased: u64,
+    purchased: u64,
     /// Premium ticket
-    pub premium: u64,
+    premium: u64,
     /// Point that you have
     #[serde(rename = "pp")]
-    pub point: u64,
+    point: u64,
     /// New bonus ticket
-    pub new_bonus: u64,
+    new_bonus: u64,
     /// The request payload
-    pub payload: String,
+    payload: String,
     #[serde(rename = "next_pp_second")]
-    pub next_point_second: u64,
+    next_point_second: u64,
     #[serde(rename = "next_pp_time")]
-    pub next_point_time: u64,
+    next_point_time: u64,
     #[serde(rename = "next_pp")]
-    pub next_point: u64,
-    pub available_wall: bool,
+    next_point: u64,
+    available_wall: bool,
     /// The account identifier for the user
     ///
     /// This is different between each token.
-    pub guest_id: String,
+    guest_id: String,
 }
 
 impl IAPInfo {
@@ -44,79 +45,109 @@ impl IAPInfo {
     pub fn sum_point(&self) -> u64 {
         self.point + self.new_bonus
     }
+
+    /// Set premium ticket amount
+    pub fn set_premium(&mut self, premium: u64) {
+        self.premium = premium;
+    }
+
+    /// Set bonus ticket amount
+    pub fn set_bonus(&mut self, bonus: u64) {
+        self.bonus = bonus;
+    }
+
+    /// Set purchased ticket amount
+    pub fn set_purchased(&mut self, purchased: u64) {
+        self.purchased = purchased;
+    }
+
+    /// Subtract premium ticket amount
+    pub fn subtract_premium(&mut self, premium: u64) {
+        self.premium = self.premium.saturating_sub(premium);
+    }
+
+    /// Subtract bonus ticket amount
+    pub fn subtract_bonus(&mut self, bonus: u64) {
+        self.bonus = self.bonus.saturating_sub(bonus);
+    }
+
+    /// Subtract purchased ticket amount
+    pub fn subtract_purchased(&mut self, purchased: u64) {
+        self.purchased = self.purchased.saturating_sub(purchased);
+    }
 }
 
 /// A node of each available purchase product
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct IAPProductInfoNode {
     /// The product identifier
     #[serde(rename = "product_id")]
-    pub id: String,
+    id: String,
     /// The product notice (sometimes is the name or description)
-    pub notice: String,
+    notice: String,
 }
 
 /// A wrapper for [`IAPProductInfoNode`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct IAPProductInfo {
     /// The product information
     #[serde(rename = "iap_product_info")]
-    pub info: IAPProductInfoNode,
+    info: IAPProductInfoNode,
 }
 
 /// A complete in-app purchase information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct IAPRemainder {
     /// The in-app purchase information
     #[serde(rename = "iap_info")]
-    pub info: IAPInfo,
+    info: IAPInfo,
     /// The in-app purchase product list
     #[serde(rename = "iap_product_list")]
-    pub product_list: Option<Vec<IAPProductInfo>>,
+    product_list: Option<Vec<IAPProductInfo>>,
     /// The in-app purchase product version
     #[serde(rename = "iap_product_version")]
-    pub version: Option<u64>,
+    version: Option<u64>,
 }
 
 /// The result of a login request
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct LoginResult {
     /// The account ID
     #[serde(rename = "citi_id")]
-    pub id: u64,
+    id: u64,
     /// The account username
     #[serde(rename = "p_name")]
-    pub name: String,
+    name: String,
     /// The account image URL
     #[serde(rename = "profile_img_url")]
-    pub image_url: String,
+    image_url: String,
     /// Is the account a guest account?
-    pub temp: bool,
+    temp: bool,
     /// The login message, if any
-    pub login_message: Option<String>,
+    login_message: Option<String>,
     /// In-app purchase information
     #[serde(rename = "iap_info")]
-    pub info: IAPInfo,
+    info: IAPInfo,
 }
 
 /// A minimal user account information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct AccountUserInfo {
     /// The account ID
     #[serde(rename = "citi_id")]
-    pub id: u64,
+    id: u64,
     /// The account username
     #[serde(rename = "p_name")]
-    pub name: String,
+    name: String,
     /// The account image URL
     #[serde(rename = "prof_image_url")]
-    pub image_url: String,
+    image_url: String,
 }
 
 /// Response for user account information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct AccountUserResponse {
     /// The account information
     #[serde(rename = "user_info")]
-    pub info: AccountUserInfo,
+    info: AccountUserInfo,
 }

--- a/tosho_amap/src/models/comic.rs
+++ b/tosho_amap/src/models/comic.rs
@@ -159,6 +159,7 @@ pub struct ComicEpisodeInfoNode {
     /// The episode expiry time in UNIX timestamp
     #[serde(rename = "i_expire_time")]
     expiry_time: Option<u64>,
+    #[allow(clippy::missing_docs_in_private_items)]
     close_time: Option<u64>, // ???
     /// The volume that includes the episode
     #[serde(rename = "included_volume")]
@@ -342,6 +343,7 @@ pub struct ComicReadInfo {
     likes: String,
     /// My likes on the episode
     my_likes: u64,
+    #[allow(clippy::missing_docs_in_private_items)]
     post_remain: u64, // ???
     /// The episode pages list
     #[serde(rename = "iap_url_list")]

--- a/tosho_amap/src/models/comic.rs
+++ b/tosho_amap/src/models/comic.rs
@@ -3,165 +3,166 @@
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
 use serde::{Deserialize, Serialize};
+use tosho_macros::AutoGetter;
 
 use super::{ComicStatus, IAPInfo};
 
 /// A simple comic information node used in search and discovery.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicSimpleInfoNode {
     /// The comic ID
     #[serde(rename = "manga_sele_id")]
-    pub id: u64,
+    id: u64,
     /// The comic title
-    pub title: String,
+    title: String,
     /// The comic last update in UNIX timestamp
-    pub update_date: Option<u64>,
+    update_date: Option<u64>,
     /// The comic cover URL
-    pub cover_url: String,
+    cover_url: String,
     /// Is there any new update?
     #[serde(rename = "new_flg")]
-    pub new_update: bool,
+    new_update: bool,
 }
 
 /// Wrapper for [`ComicSimpleInfoNode`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicSimpleInfo {
     /// The comic information
     #[serde(rename = "comic_info")]
-    pub info: ComicSimpleInfoNode,
+    info: ComicSimpleInfoNode,
 }
 
 /// The current banner information for the comic discovery.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicBannerInfoNode {
     /// The comic ID
     #[serde(rename = "manga_sele_id")]
-    pub id: u64,
+    id: u64,
     /// The comic banner URL
     #[serde(rename = "url")]
-    pub cover_url: String,
+    cover_url: String,
 }
 
 /// Wrapper for [`ComicBannerInfoNode`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicBannerInfo {
     /// The comic banner information
     #[serde(rename = "banner")]
-    pub info: ComicBannerInfoNode,
+    info: ComicBannerInfoNode,
 }
 
 /// The comic discovery header information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicDiscoveryHeader {
     /// The comic discovery header ID
-    pub title: String,
+    title: String,
     /// The comic discovery tag ID if it's a tag
-    pub tag_id: Option<u64>,
+    tag_id: Option<u64>,
     /// Is the comic discovery is a completed comic?
-    pub complete: Option<u64>, // what?
+    complete: Option<u64>, // what?
 }
 
 /// The comic discovery node.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicDiscoveryNode {
     /// The discovery node header
-    pub header: ComicDiscoveryHeader,
+    header: ComicDiscoveryHeader,
     /// The discovery node comics
     #[serde(rename = "comic_info_list")]
-    pub comics: Vec<ComicSimpleInfo>,
+    comics: Vec<ComicSimpleInfo>,
 }
 
 /// The paginated response for comic discovery.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicDiscoveryPaginatedResponse {
     /// The discovery node comics
     #[serde(rename = "comic_info_list")]
-    pub comics: Vec<ComicSimpleInfo>,
+    comics: Vec<ComicSimpleInfo>,
     /// Is there any next page?
-    pub next_page: bool,
+    next_page: bool,
 }
 
 /// The search response for comic discovery.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicSearchResponse {
     /// The discovery node comics
     #[serde(rename = "comic_info_list")]
-    pub comics: Vec<ComicSimpleInfo>,
+    comics: Vec<ComicSimpleInfo>,
     /// The total count of the search results
-    pub total_count: String,
+    total_count: String,
     /// Is there any next page?
-    pub next_page: bool,
+    next_page: bool,
 }
 
 /// The comic discovery response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicDiscovery {
     /// The comic discovery banners
     #[serde(rename = "manga_banner_list")]
-    pub banners: Vec<ComicBannerInfo>,
+    banners: Vec<ComicBannerInfo>,
     /// The comic discovery updated comics
-    pub updated: Vec<ComicDiscoveryNode>,
+    updated: Vec<ComicDiscoveryNode>,
     /// The comic discovery free campaigns
-    pub free_campaigns: Vec<ComicDiscoveryNode>,
+    free_campaigns: Vec<ComicDiscoveryNode>,
     /// The comic discovery (first tags, random tags)
     #[serde(rename = "tag_contents1")]
-    pub tags1: Vec<ComicDiscoveryNode>,
+    tags1: Vec<ComicDiscoveryNode>,
     /// The comic discovery (second tags, random tags)
     #[serde(rename = "tag_contents2")]
-    pub tags2: Vec<ComicDiscoveryNode>,
+    tags2: Vec<ComicDiscoveryNode>,
     /// The comic discovery completed comics
-    pub completed: Vec<ComicDiscoveryNode>,
+    completed: Vec<ComicDiscoveryNode>,
 }
 
 /// The comic free daily ticket usage information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicInfoFreeDaily {
     /// The next free daily time in UNIX timestamp
     #[serde(rename = "next_free_daily_time")]
-    pub next: u64,
+    next: u64,
     /// The free daily term, used when requesting for the comic viewer
     #[serde(rename = "free_daily_term")]
-    pub term: String,
+    term: String,
 }
 
 /// A single comic episode information node.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicEpisodeInfoNode {
     /// The episode ID
     #[serde(rename = "story_no")]
-    pub id: u64,
+    id: u64,
     /// The episode title
-    pub title: String,
+    title: String,
     /// The episode price
     #[serde(rename = "i_price")]
-    pub price: u64,
+    price: u64,
     /// The episode update date in UNIX timestamp
     #[serde(rename = "update_timestamp")]
-    pub update_date: u64,
+    update_date: u64,
     /// The episode thumbnail URL
-    pub thumbnail: String,
+    thumbnail: String,
     /// The episode likes
-    pub likes: String,
+    likes: String,
     /// The episode comments
-    pub comments: String,
+    comments: String,
     /// The episode total page count
     #[serde(rename = "total_page_count")]
-    pub page_count: u64,
+    page_count: u64,
     /// The episode start status
     #[serde(rename = "page_start_status")]
-    pub start_status: i32,
+    start_status: i32,
     /// Does the episode can be purchased with the free daily ticket?
     #[serde(rename = "is_free_daily_episode")]
-    pub is_free_daily: bool,
+    is_free_daily: bool,
     /// The episode free campaign end date in UNIX timestamp
-    pub campaign_end_at: Option<u64>,
+    campaign_end_at: Option<u64>,
     /// The episode expiry time in UNIX timestamp
     #[serde(rename = "i_expire_time")]
-    pub expiry_time: Option<u64>,
-    pub close_time: Option<u64>, // ???
+    expiry_time: Option<u64>,
+    close_time: Option<u64>, // ???
     /// The volume that includes the episode
     #[serde(rename = "included_volume")]
-    pub included_in: Option<String>,
+    included_in: Option<String>,
 }
 
 impl ComicEpisodeInfoNode {
@@ -178,188 +179,187 @@ impl ComicEpisodeInfoNode {
 }
 
 /// Wrapper for [`ComicEpisodeInfoNode`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicEpisodeInfo {
     /// The episode information
     #[serde(rename = "comic_body_info")]
-    pub info: ComicEpisodeInfoNode,
+    info: ComicEpisodeInfoNode,
 }
 
 /// Author information node on a series/comic.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicAuthorInfoNode {
     /// The author ID
     #[serde(rename = "a_id")]
-    pub id: u64,
+    id: u64,
     /// The author name
     #[serde(rename = "a_name")]
-    pub name: String,
+    name: String,
     /// The author kind (e.g. "Author", "Illustrator")
     #[serde(rename = "disp_a_kind")]
-    pub kind: String,
+    kind: String,
     /// The author description
     #[serde(rename = "a_comment")]
-    pub description: Option<String>,
+    description: Option<String>,
 }
 
 /// Wrapper for [`ComicAuthorInfoNode`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicAuthorInfo {
     /// The author information
     #[serde(rename = "author_info")]
-    pub info: ComicAuthorInfoNode,
+    info: ComicAuthorInfoNode,
 }
 
 /// Tag information node on a series/comic.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicTagInfoNode {
     /// The tag ID
     #[serde(rename = "tag_id")]
-    pub id: u64,
+    id: u64,
     /// The tag name
     #[serde(rename = "tag_name")]
-    pub name: String,
+    name: String,
 }
 
 /// Wrapper for [`ComicTagInfoNode`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicTagInfo {
     /// The tag information
     #[serde(rename = "tag_info")]
-    pub info: ComicTagInfoNode,
+    info: ComicTagInfoNode,
 }
 
 /// A complete comic information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicInfo {
     /// The comic title
-    pub title: String,
+    title: String,
     /// The comic description
     #[serde(rename = "shoukai")]
-    pub description: String,
+    description: String,
     /// The comic last update in UNIX timestamp, if any
-    pub update_date: Option<u64>,
+    update_date: Option<u64>,
     /// The comic next update in UNIX timestamp
-    pub next_update_date: Option<u64>,
+    next_update_date: Option<u64>,
     /// The comic cover URL
-    pub cover_url: String,
+    cover_url: String,
     /// The comic thumbnail URL
-    pub thumbnail_url: String,
+    thumbnail_url: String,
     /// The comic web outgoing URL
     #[serde(rename = "cont_url")]
-    pub web_url: Option<String>,
+    web_url: Option<String>,
     /// The comic episodes list
     #[serde(rename = "comic_body_info_list")]
-    pub episodes: Vec<ComicEpisodeInfo>,
+    episodes: Vec<ComicEpisodeInfo>,
     /// The comic next update text
-    pub next_update_text: Option<String>,
+    next_update_text: Option<String>,
     /// Is the comic a favorite?
-    pub favorite: bool,
+    favorite: bool,
     /// The comic rental term (used when requesting for the comic viewer)
-    pub rental_term: Option<String>,
+    rental_term: Option<String>,
     /// The comic authors list
     #[serde(rename = "author_info_list")]
-    pub authors: Vec<ComicAuthorInfo>,
+    authors: Vec<ComicAuthorInfo>,
     /// The comic tags list
     #[serde(rename = "tag_info_list")]
-    pub tags: Vec<ComicTagInfo>,
+    tags: Vec<ComicTagInfo>,
     /// The comic likes
-    pub likes: String,
+    likes: String,
     /// The comic comments
-    pub comments: String,
+    comments: String,
     /// The comic status
     #[serde(rename = "complete")]
-    pub status: ComicStatus,
+    status: ComicStatus,
     /// The comic production participants (usually the Translator)
     #[serde(rename = "production_participants")]
-    pub productions: String,
+    productions: String,
     /// Is the comic has episode that can use the free daily ticket?
     #[serde(rename = "is_free_daily")]
-    pub has_free_daily: bool,
+    has_free_daily: bool,
     /// The comic free daily ticket information, if any.
-    pub free_daily: Option<ComicInfoFreeDaily>,
+    free_daily: Option<ComicInfoFreeDaily>,
 }
 
 /// A single volume information node.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicVolumeBookInfoNode {
     /// The volume title
-    pub title: String,
+    title: String,
     /// The volume cover URL
-    pub cover_url: String,
+    cover_url: String,
     /// The volume detail URL, usually outgoing link to Amazon (shortened with x.gd)
-    pub detail_url: String,
+    detail_url: String,
 }
 
 /// Wrapper for [`ComicVolumeBookInfoNode`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicVolumeBookInfo {
     /// The volume information
     #[serde(rename = "book_info")]
-    pub info: ComicVolumeBookInfoNode,
+    info: ComicVolumeBookInfoNode,
 }
 
 /// The comic information response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicInfoResponse {
     /// The comic information
     #[serde(rename = "comic_info")]
-    pub info: ComicInfo,
+    info: ComicInfo,
     /// The comic volumes list
     #[serde(rename = "book_info_list")]
-    pub volumes: Vec<ComicVolumeBookInfo>,
+    volumes: Vec<ComicVolumeBookInfo>,
     /// The in-app purchase information
     #[serde(rename = "iap_info")]
-    pub account: IAPInfo,
+    account: IAPInfo,
 }
 
 /// The comic read page information node.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicReadPageNode {
     /// The page URL
-    pub url: String,
+    url: String,
 }
 
 /// Wrapper for [`ComicReadPageNode`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicReadPage {
     /// The page information
     #[serde(rename = "iap_url_info")]
-    pub info: ComicReadPageNode,
+    info: ComicReadPageNode,
 }
 
 /// The comic read information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicReadInfo {
     /// The episode ID
     #[serde(rename = "story_no")]
-    pub id: u64,
+    id: u64,
     /// The episode expiry time in UNIX timestamp
     #[serde(rename = "i_expire_time")]
-    pub expiry_time: Option<u64>,
+    expiry_time: Option<u64>,
     /// The episode likes
-    pub likes: String,
+    likes: String,
     /// My likes on the episode
-    pub my_likes: u64,
-    /// ????
-    pub post_remain: u64,
+    my_likes: u64,
+    post_remain: u64, // ???
     /// The episode pages list
     #[serde(rename = "iap_url_list")]
-    pub pages: Vec<ComicReadPage>,
+    pages: Vec<ComicReadPage>,
     /// The episode last page URL
     #[serde(rename = "last_page_announce_url")]
-    pub last_page: Option<String>,
+    last_page: Option<String>,
 }
 
 /// The comic read response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ComicReadResponse {
     /// The episode information
     #[serde(rename = "iap_story_info")]
-    pub info: ComicReadInfo,
+    info: ComicReadInfo,
     /// The free daily ticket information, if any.
-    pub free_daily: Option<ComicInfoFreeDaily>,
+    free_daily: Option<ComicInfoFreeDaily>,
     /// The in-app purchase information
     #[serde(rename = "iap_info")]
-    pub account: IAPInfo,
+    account: IAPInfo,
 }

--- a/tosho_amap/src/models/common.rs
+++ b/tosho_amap/src/models/common.rs
@@ -4,34 +4,35 @@
 
 use serde::{Deserialize, Serialize};
 use tosho_common::FailableResponse;
+use tosho_macros::AutoGetter;
 
 use super::AMAPIError;
 
 /// The header of each request result.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize, PartialEq)]
 pub struct ResultHeader {
     /// The result of the request.
-    pub result: bool,
+    result: bool,
     /// Error message.
-    pub message: Option<String>,
+    message: Option<String>,
 }
 
 /// The body which contains error message.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ErrorBody {
     #[serde(rename = "error_code")]
-    pub code: i32,
+    code: i32,
     #[serde(rename = "error_message_list")]
-    pub messages: Vec<String>,
+    messages: Vec<String>,
 }
 
 /// Wrapper for [`ResultHeader`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct StatusResult {
     /// The result of the request.
-    pub header: ResultHeader,
+    header: ResultHeader,
     #[serde(default)]
-    pub body: Option<serde_json::Value>,
+    body: Option<serde_json::Value>,
 }
 
 impl FailableResponse for StatusResult {
@@ -47,32 +48,6 @@ impl FailableResponse for StatusResult {
     }
 
     /// Raise/return an error if the response code is not 0.
-    ///
-    /// # Examples
-    /// ```
-    /// use tosho_common::FailableResponse;
-    /// use tosho_amap::models::{ResultHeader, StatusResult};
-    ///
-    /// let response = StatusResult {
-    ///     header: ResultHeader {
-    ///         result: true,
-    ///         message: None,
-    ///     },
-    ///     body: None,
-    /// };
-    ///
-    /// assert!(response.raise_for_status().is_ok());
-    ///
-    /// let response = StatusResult {
-    ///     header: ResultHeader {
-    ///         result: false,
-    ///         message: Some("An error occurred".to_string()),
-    ///     },
-    ///     body: None,
-    /// };
-    ///
-    /// assert!(response.raise_for_status().is_err());
-    /// ```
     fn raise_for_status(&self) -> Result<(), tosho_common::ToshoError> {
         if !self.header.result {
             let message = self
@@ -89,29 +64,29 @@ impl FailableResponse for StatusResult {
 }
 
 /// The result of the request.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct AMResult<R> {
     /// The result of the request.
-    pub header: ResultHeader,
+    header: ResultHeader,
     /// The content of the request.
     #[serde(bound(
         deserialize = "R: Deserialize<'de>, R: Clone",
         serialize = "R: Serialize, R: Clone"
     ))]
-    pub body: Option<R>,
+    body: Option<R>,
 }
 
 /// The result of the request.
 ///
 /// Wrapper for [`AMResult`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct APIResult<R> {
     /// The content of the request.
     #[serde(bound(
         deserialize = "R: Deserialize<'de>, R: Clone",
         serialize = "R: Serialize, R: Clone"
     ))]
-    pub result: AMResult<R>,
+    result: AMResult<R>,
 }
 
 #[cfg(test)]

--- a/tosho_amap/src/models/common.rs
+++ b/tosho_amap/src/models/common.rs
@@ -20,8 +20,10 @@ pub struct ResultHeader {
 /// The body which contains error message.
 #[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ErrorBody {
+    /// The error response code
     #[serde(rename = "error_code")]
     code: i32,
+    /// The list of error messages
     #[serde(rename = "error_message_list")]
     messages: Vec<String>,
 }
@@ -31,6 +33,7 @@ pub struct ErrorBody {
 pub struct StatusResult {
     /// The result of the request.
     header: ResultHeader,
+    /// The content of the response, this is just a stub
     #[serde(default)]
     body: Option<serde_json::Value>,
 }

--- a/tosho_amap/src/models/enums.rs
+++ b/tosho_amap/src/models/enums.rs
@@ -2,7 +2,6 @@
 //!
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
-use serde::{Deserialize, Serialize};
 use tosho_macros::{DeserializeEnum32, EnumName, SerializeEnum32};
 
 /// A status of a comic.

--- a/tosho_amap/src/models/enums.rs
+++ b/tosho_amap/src/models/enums.rs
@@ -5,7 +5,7 @@
 use tosho_macros::{DeserializeEnum32, EnumName, SerializeEnum32};
 
 /// A status of a comic.
-#[derive(Debug, Clone, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
+#[derive(Debug, Clone, Copy, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
 pub enum ComicStatus {
     /// The comic is completed.
     Complete = 1,

--- a/tosho_amap/src/models/errors.rs
+++ b/tosho_amap/src/models/errors.rs
@@ -5,7 +5,7 @@
 use tosho_common::{make_error, ToshoError};
 
 /// The used error type for the API.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AMAPIError {
     /// The error message from the API.
     pub message: String,

--- a/tosho_amap/src/models/mod.rs
+++ b/tosho_amap/src/models/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
+#![warn(clippy::missing_docs_in_private_items)]
+
 pub mod accounts;
 pub mod comic;
 pub mod common;

--- a/tosho_common/src/errors.rs
+++ b/tosho_common/src/errors.rs
@@ -204,6 +204,7 @@ pub struct ToshoDetailedImageError {
 
 #[cfg(feature = "image")]
 impl ToshoDetailedImageError {
+    /// Create a new instance of image errow with a more detailed response
     pub fn new(inner: image::ImageError, description: impl Into<String>) -> Self {
         Self {
             inner,

--- a/tosho_common/src/lib.rs
+++ b/tosho_common/src/lib.rs
@@ -1,4 +1,6 @@
+#![warn(missing_docs, clippy::empty_docs, rustdoc::broken_intra_doc_links)]
 #![doc = include_str!("../README.md")]
+
 pub mod errors;
 #[cfg(feature = "id-gen")]
 pub mod generator;

--- a/tosho_kmkc/README.md
+++ b/tosho_kmkc/README.md
@@ -15,12 +15,7 @@ use tosho_kmkc::{KMClient, KMConfig, KMConfigMobile, KMConfigMobilePlatform};
 
 #[tokio::main]
 async fn main() {
-    let config = KMConfigMobile {
-        user_id: "123".to_string(),
-        hash_key: "abcxyz".to_string(),
-        platform: KMConfigMobilePlatform::Android,
-    };
-
+    let config = KMConfigMobile::new("123", "abcxyz", KMConfigMobilePlatform::Android);
     let client = KMClient::new(KMConfig::Mobile(config)).unwrap();
 
     let manga = client.get_titles(vec![10007]).await.unwrap();

--- a/tosho_kmkc/src/config.rs
+++ b/tosho_kmkc/src/config.rs
@@ -3,11 +3,7 @@
 //! ```rust
 //! use tosho_kmkc::{KMConfigMobile, KMConfigMobilePlatform};
 //!
-//! let config = KMConfigMobile {
-//!     user_id: "123".to_string(),
-//!     hash_key: "abcxyz".to_string(),
-//!     platform: KMConfigMobilePlatform::Android,
-//! };
+//! let config = KMConfigMobile::new("123", "abcxyz", KMConfigMobilePlatform::Android);
 //! ```
 
 use reqwest::Url;

--- a/tosho_kmkc/src/config.rs
+++ b/tosho_kmkc/src/config.rs
@@ -13,27 +13,44 @@
 use reqwest::Url;
 use reqwest_cookie_store::{CookieStoreMutex, RawCookie};
 use tosho_common::{bail_on_error, make_error, ToshoAuthError, ToshoError, ToshoResult};
-use tosho_macros::{EnumName, EnumU32};
+use tosho_macros::{AutoGetter, EnumName, EnumU32};
 use urlencoding::{decode, encode};
 
 use crate::constants::BASE_HOST;
 
 /// Key value mapping for web cookies
-#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+#[derive(Clone, Debug, AutoGetter, serde::Deserialize, serde::Serialize)]
 pub struct KMConfigWebKV {
     /// The value of the cookie/key
-    pub value: String,
+    value: String,
     /// The expiry of the cookie/key
-    pub expires: i64,
+    expires: i64,
+}
+
+impl KMConfigWebKV {
+    /// Create a new instance of expiry key-value
+    pub fn new(value: impl Into<String>, expires: i64) -> Self {
+        Self {
+            value: value.into(),
+            expires,
+        }
+    }
 }
 
 /// Key value mapping for web cookies with [`i64`] as a value
-#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+#[derive(Clone, Copy, Debug, AutoGetter, serde::Deserialize, serde::Serialize)]
 pub struct KMConfigWebKV64 {
     /// The value of the cookie/key
-    pub value: i64,
+    value: i64,
     /// The expiry of the cookie/key
-    pub expires: i64,
+    expires: i64,
+}
+
+impl KMConfigWebKV64 {
+    /// Create a new instance of expiry key-value
+    pub fn new(value: i64, expires: i64) -> Self {
+        Self { value, expires }
+    }
 }
 
 impl TryFrom<&KMConfigWebKV> for KMConfigWebKV64 {
@@ -132,16 +149,33 @@ impl KMConfigWebKV {
 }
 
 /// Represents the config/cookies for the web implementation
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, AutoGetter)]
 pub struct KMConfigWeb {
     /// The auth token for KM KC
-    pub uwt: String,
+    uwt: String,
     /// Account birthday information.
-    pub birthday: KMConfigWebKV,
+    birthday: KMConfigWebKV,
     /// Account adult ToS aggreement status.
-    pub tos_adult: KMConfigWebKV,
+    tos_adult: KMConfigWebKV,
     /// Account privacy policy agreement status.
-    pub privacy: KMConfigWebKV,
+    privacy: KMConfigWebKV,
+}
+
+impl KMConfigWeb {
+    /// Create a new instance of [`KMConfigWeb`] config
+    pub fn new(
+        uwt: impl Into<String>,
+        birthday: KMConfigWebKV,
+        tos_adult: KMConfigWebKV,
+        privacy: KMConfigWebKV,
+    ) -> Self {
+        Self {
+            uwt: uwt.into(),
+            birthday,
+            tos_adult,
+            privacy,
+        }
+    }
 }
 
 impl TryFrom<reqwest_cookie_store::CookieStore> for KMConfigWeb {
@@ -293,7 +327,7 @@ impl Default for KMConfigWeb {
 }
 
 /// The mobile platform to use
-#[derive(Debug, Clone, EnumName, EnumU32)]
+#[derive(Debug, Clone, Copy, EnumName, EnumU32)]
 #[repr(u8)]
 pub enum KMConfigMobilePlatform {
     /// Apple/iOS
@@ -303,11 +337,30 @@ pub enum KMConfigMobilePlatform {
 }
 
 /// Represents the mobile config
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, AutoGetter)]
 pub struct KMConfigMobile {
-    pub user_id: String,
-    pub hash_key: String,
-    pub platform: KMConfigMobilePlatform,
+    /// The user ID
+    user_id: String,
+    /// The user hash key information
+    hash_key: String,
+    /// The user platform
+    #[copyable]
+    platform: KMConfigMobilePlatform,
+}
+
+impl KMConfigMobile {
+    /// Create a new instance of [`KMConfigMobile`]
+    pub fn new(
+        user_id: impl Into<String>,
+        hash_key: impl Into<String>,
+        platform: KMConfigMobilePlatform,
+    ) -> Self {
+        Self {
+            user_id: user_id.into(),
+            hash_key: hash_key.into(),
+            platform,
+        }
+    }
 }
 
 /// Represents the config for the KM KC

--- a/tosho_kmkc/src/constants.rs
+++ b/tosho_kmkc/src/constants.rs
@@ -196,9 +196,9 @@ pub static RANKING_TABS: LazyLock<Vec<RankingTab>> = LazyLock::new(|| {
 /// Panics if the device type is invalid.
 ///
 /// # Examples
-/// ```
-/// use tosho_kmkc::constants::get_constants;
-///
+/// ```rust
+/// # use tosho_kmkc::constants::get_constants;
+/// #
 /// let _ = get_constants(2); // Android
 /// let _ = get_constants(3); // Web
 /// ```

--- a/tosho_kmkc/src/imaging.rs
+++ b/tosho_kmkc/src/imaging.rs
@@ -96,7 +96,7 @@ fn generate_copy_targets(rectbox: u32, seed: u32) -> Vec<((u32, u32), (u32, u32)
 ///                     response.
 ///
 /// # Example
-/// ```no_run
+/// ```rust,no_run
 /// use tosho_kmkc::imaging::descramble_image;
 ///
 /// let img_bytes = [0_u8; 100];

--- a/tosho_kmkc/src/lib.rs
+++ b/tosho_kmkc/src/lib.rs
@@ -1,3 +1,9 @@
+#![warn(
+    missing_docs,
+    clippy::empty_docs,
+    rustdoc::broken_intra_doc_links,
+    clippy::missing_docs_in_private_items
+)]
 #![doc = include_str!("../README.md")]
 
 use std::{collections::HashMap, sync::MutexGuard};

--- a/tosho_kmkc/src/lib.rs
+++ b/tosho_kmkc/src/lib.rs
@@ -1,9 +1,4 @@
-#![warn(
-    missing_docs,
-    clippy::empty_docs,
-    rustdoc::broken_intra_doc_links,
-    clippy::missing_docs_in_private_items
-)]
+#![warn(missing_docs, clippy::empty_docs, rustdoc::broken_intra_doc_links)]
 #![doc = include_str!("../README.md")]
 
 use std::{collections::HashMap, sync::MutexGuard};

--- a/tosho_kmkc/src/lib.rs
+++ b/tosho_kmkc/src/lib.rs
@@ -572,11 +572,15 @@ impl KMClient {
     /// # Arguments
     /// * `query` - The query to search for
     /// * `limit` - The limit of results to return
-    pub async fn search(&self, query: &str, limit: Option<u32>) -> ToshoResult<Vec<TitleNode>> {
+    pub async fn search(
+        &self,
+        query: impl Into<String>,
+        limit: Option<u32>,
+    ) -> ToshoResult<Vec<TitleNode>> {
         let mut params = HashMap::new();
-        params.insert("keyword".to_owned(), query.to_owned());
+        params.insert("keyword".to_string(), query.into());
         let limit = limit.unwrap_or(99_999);
-        params.insert("limit".to_owned(), limit.to_string());
+        params.insert("limit".to_string(), limit.to_string());
 
         let response = self
             .request::<SearchResponse>(
@@ -737,10 +741,11 @@ impl KMClient {
     /// * `writer` - The writer to write the image to
     pub async fn stream_download(
         &self,
-        url: &str,
+        url: impl Into<String>,
         scramble_seed: Option<u32>,
         mut writer: impl tokio::io::AsyncWrite + std::marker::Unpin,
     ) -> ToshoResult<()> {
+        let url: String = url.into();
         let res = self
             .inner
             .get(url)
@@ -801,8 +806,8 @@ impl KMClient {
     /// * `password` - The password to login with
     /// * `mobile` - Whether to login as mobile or not
     pub async fn login(
-        email: &str,
-        password: &str,
+        email: impl Into<String>,
+        password: impl Into<String>,
         mobile_platform: Option<KMConfigMobilePlatform>,
     ) -> ToshoResult<KMLoginResult> {
         // Create a new client
@@ -835,8 +840,8 @@ impl KMClient {
 
         // Perform web login
         let mut req_data = HashMap::new();
-        req_data.insert("email".to_string(), email.to_string());
-        req_data.insert("password".to_string(), password.to_string());
+        req_data.insert("email".to_string(), email.into());
+        req_data.insert("password".to_string(), password.into());
         req_data.insert("platform".to_string(), WEB_CONSTANTS.platform.to_string());
         req_data.insert("version".to_string(), WEB_CONSTANTS.version.to_string());
 

--- a/tosho_kmkc/src/models/account.rs
+++ b/tosho_kmkc/src/models/account.rs
@@ -88,13 +88,13 @@ impl UserPoint {
     ///
     /// user_point.subtract(5);
     ///
-    /// assert_eq!(user_point.paid_point, 10);
-    /// assert_eq!(user_point.free_point, 5);
+    /// assert_eq!(user_point.paid_point(), 10);
+    /// assert_eq!(user_point.free_point(), 5);
     ///
     /// user_point.subtract(10);
     ///
-    /// assert_eq!(user_point.free_point, 0);
-    /// assert_eq!(user_point.paid_point, 5);
+    /// assert_eq!(user_point.free_point(), 0);
+    /// assert_eq!(user_point.paid_point(), 5);
     /// ```
     pub fn subtract(&mut self, price: u64) {
         if !self.can_purchase(price) {
@@ -119,8 +119,8 @@ impl UserPoint {
     ///
     /// user_point.add(10);
     ///
-    /// assert_eq!(user_point.free_point, 10);
-    /// assert_eq!(user_point.paid_point, 0);
+    /// assert_eq!(user_point.free_point(), 10);
+    /// assert_eq!(user_point.paid_point(), 0);
     /// ```
     pub fn add(&mut self, bonus: u64) {
         self.free_point += bonus;

--- a/tosho_kmkc/src/models/account.rs
+++ b/tosho_kmkc/src/models/account.rs
@@ -4,26 +4,28 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tosho_macros::AutoGetter;
 
 use super::{DevicePlatform, EpisodeBadge, GenderType, IntBool};
 
 /// The user point information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct UserPoint {
     /// The paid/purchased point that the user have.
-    pub paid_point: u64,
+    paid_point: u64,
     /// The free point that the user have.
-    pub free_point: u64,
+    free_point: u64,
     /// The point sale text, currently unknown what it is.
     #[serde(rename = "point_sale_text")]
-    pub point_sale: Option<String>,
+    point_sale: Option<String>,
     /// The point sale finish datetime string.
     #[serde(
         rename = "point_sale_finish_datetime",
         serialize_with = "super::datetime::serialize_opt",
         deserialize_with = "super::datetime::deserialize_opt"
     )]
-    pub point_sale_finish: Option<DateTime<Utc>>,
+    #[copyable]
+    point_sale_finish: Option<DateTime<Utc>>,
 }
 
 impl UserPoint {
@@ -126,98 +128,106 @@ impl UserPoint {
 }
 
 /// The user ticket information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize)]
 pub struct UserTicket {
     /// The ticket that the user have.
-    pub total_num: u64,
+    total_num: u64,
 }
 
 /// Represents the user account point Response.
 ///
 /// You should use it in combination of [`crate::models::StatusResponse`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct UserPointResponse {
     /// The user point information.
-    pub point: UserPoint,
+    point: UserPoint,
     /// The premium ticket information.
-    pub ticket: UserTicket,
+    #[copyable]
+    ticket: UserTicket,
 }
 
 /// Title that the user favorited
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct UserFavoriteList {
     /// The last updated time of the free episode.
-    pub free_episode_updated: String,
+    free_episode_updated: String,
     /// The last updated time of the paid episode.
-    pub paid_episode_updated: String,
+    paid_episode_updated: String,
     /// Is there any unread free episode.
-    pub is_unread_free_episode: IntBool,
+    #[copyable]
+    is_unread_free_episode: IntBool,
     /// Purchase status of the manga.
-    pub purchase_status: EpisodeBadge,
+    #[copyable]
+    purchase_status: EpisodeBadge,
     /// The title ticket recover time.
-    pub ticket_recover_time: String,
+    ticket_recover_time: String,
     /// The title ID.
-    pub title_id: i32,
+    title_id: i32,
 }
 
 /// The device info of a user account
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct UserAccountDevice {
     /// The user ID or device ID
     #[serde(rename = "user_id")]
-    pub id: u32,
+    id: u32,
     /// The device name
     #[serde(rename = "device_name")]
-    pub name: String,
+    name: String,
     /// The device platform
-    pub platform: DevicePlatform,
+    #[copyable]
+    platform: DevicePlatform,
 }
 
 /// The user account information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct UserAccount {
     /// The account ID
     #[serde(rename = "account_id")]
-    pub id: u32,
+    id: u32,
     /// The account user ID
-    pub user_id: u32,
+    user_id: u32,
     /// The user name
     #[serde(rename = "nickname")]
-    pub name: Option<String>,
+    name: Option<String>,
     /// The user email
-    pub email: String,
+    email: String,
     /// The user gender
-    pub gender: Option<GenderType>,
+    #[copyable]
+    gender: Option<GenderType>,
     /// The user birth year
     #[serde(rename = "birthyear")]
-    pub birth_year: Option<i32>,
+    birth_year: Option<i32>,
     /// The list of registered devices
     #[serde(rename = "device_list")]
-    pub devices: Vec<UserAccountDevice>,
+    devices: Vec<UserAccountDevice>,
     /// Whether the account is registered or not.
     #[serde(rename = "is_registerd")]
-    pub registered: IntBool,
+    #[copyable]
+    registered: IntBool,
     /// The number of days since the account is registered.
     #[serde(rename = "days_since_created")]
-    pub registered_days: i64,
+    registered_days: i64,
 }
 
 /// Represents an user account response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct AccountResponse {
     /// The user account information.
-    pub account: UserAccount,
+    account: UserAccount,
 }
 
 /// Represents the user information response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct UserInfoResponse {
+    /// The user ID
     #[serde(rename = "user_id")]
-    pub id: u32,
+    id: u32,
     /// The user email
-    pub email: String,
+    email: String,
     /// The user gender
-    pub gender: Option<GenderType>,
+    #[copyable]
+    gender: Option<GenderType>,
     /// The user hash key
-    pub hash_key: String,
+    hash_key: String,
 }

--- a/tosho_kmkc/src/models/account.rs
+++ b/tosho_kmkc/src/models/account.rs
@@ -62,7 +62,7 @@ impl UserPoint {
     /// Check if the user can purchase a chapter.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_kmkc::models::UserPoint;
     ///
     /// let user_point = UserPoint::new(0, 0);
@@ -79,7 +79,7 @@ impl UserPoint {
     /// Mutate the [`UserPoint`] to subtract the owned point by the price.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_kmkc::models::UserPoint;
     ///
     /// let mut user_point = UserPoint::new(10, 10);
@@ -110,7 +110,7 @@ impl UserPoint {
     /// Mutate the [`UserPoint`] to add a bonus point got from a chapter.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_kmkc::models::UserPoint;
     ///
     /// let mut user_point = UserPoint::new(0, 0);

--- a/tosho_kmkc/src/models/common.rs
+++ b/tosho_kmkc/src/models/common.rs
@@ -4,51 +4,30 @@
 
 use serde::{Deserialize, Serialize};
 use tosho_common::FailableResponse;
+use tosho_macros::AutoGetter;
 
 use super::KMAPIError;
 
 /// Simple ID object model.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize)]
 pub struct SimpleId {
     /// The ID itself.
-    pub id: i32,
+    id: i32,
 }
 
 /// The base response for all API calls.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct StatusResponse {
     /// The status of the response, usually "success" or "fail".
-    pub status: String,
+    status: String,
     /// The response code of the response, usually 0 for success.
-    pub response_code: i32,
+    response_code: i32,
     /// The error message of the response, usually empty for success.
-    pub error_message: String,
+    error_message: String,
 }
 
 impl FailableResponse for StatusResponse {
     /// Raise/return an error if the response code is not 0.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use tosho_kmkc::models::StatusResponse;
-    /// use tosho_common::FailableResponse;
-    ///
-    /// let response = StatusResponse {
-    ///     status: "success".to_string(),
-    ///     response_code: 0,
-    ///     error_message: "".to_string(),
-    /// };
-    ///
-    /// assert!(response.raise_for_status().is_ok());
-    ///
-    /// let response = StatusResponse {
-    ///    status: "fail".to_string(),
-    ///    response_code: 1,
-    ///    error_message: "An error occurred".to_string(),
-    /// };
-    ///
-    /// assert!(response.raise_for_status().is_err());
-    /// ```
     fn raise_for_status(&self) -> tosho_common::ToshoResult<()> {
         if self.response_code != 0 {
             let api_error = KMAPIError {

--- a/tosho_kmkc/src/models/common.rs
+++ b/tosho_kmkc/src/models/common.rs
@@ -29,7 +29,7 @@ impl FailableResponse for StatusResponse {
     /// Raise/return an error if the response code is not 0.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_kmkc::models::StatusResponse;
     /// use tosho_common::FailableResponse;
     ///

--- a/tosho_kmkc/src/models/datetime.rs
+++ b/tosho_kmkc/src/models/datetime.rs
@@ -1,8 +1,12 @@
+//! Serde related helper for datetime format in KM
+
 use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::{Deserialize, Deserializer, Serializer};
 
+/// The datetime used by KM
 const FORMAT: &str = "%Y-%m-%d %H:%M:%S";
 
+/// Serialize a [`DateTime`] into the specified format supported by the API.
 pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -11,6 +15,7 @@ where
     serializer.serialize_str(&s)
 }
 
+/// Deserialize a specific format from API into a [`DateTime`].
 pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
 where
     D: Deserializer<'de>,
@@ -20,6 +25,7 @@ where
     Ok(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc))
 }
 
+/// Serialize an optional [`DateTime`] into the specified format supported by the API.
 pub fn serialize_opt<S>(date: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -33,6 +39,7 @@ where
     }
 }
 
+/// Deserialize an optional specific format from API into a [`DateTime`].
 pub fn deserialize_opt<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
 where
     D: Deserializer<'de>,

--- a/tosho_kmkc/src/models/enums.rs
+++ b/tosho_kmkc/src/models/enums.rs
@@ -11,7 +11,7 @@ use tosho_macros::{
 };
 
 /// A boolean type used by the API represented as an integer.
-#[derive(Debug, Clone, SerializeEnum32, DeserializeEnum32, EnumName)]
+#[derive(Debug, Clone, Copy, SerializeEnum32, DeserializeEnum32, EnumName)]
 pub enum IntBool {
     /// Property is false
     False = 0,
@@ -69,7 +69,7 @@ impl From<IntBool> for bool {
 }
 
 /// The purchase status of an episode.
-#[derive(Debug, Clone, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
+#[derive(Debug, Clone, Copy, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
 pub enum EpisodeBadge {
     /// Episode need to be purchased by point or ticket (if possible)
     Purchaseable = 1,
@@ -82,31 +82,35 @@ pub enum EpisodeBadge {
 }
 
 /// The device platform type.
-#[derive(Debug, Clone, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
+#[derive(Debug, Clone, Copy, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
 pub enum DevicePlatform {
-    // Is Apple/iOS
+    /// Is Apple/iOS
     Apple = 1,
-    // Is Android
+    /// Is Android
     Android = 2,
     /// Is Website
     Web = 3,
 }
 
 /// Gender type of the user.
-#[derive(Debug, Clone, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
+#[derive(Debug, Clone, Copy, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
 pub enum GenderType {
+    /// Male gender
     Male = 1,
+    /// Female gender
     Female = 2,
+    /// Other gender
     Other = 3,
 }
 
 /// The publication category type.
-#[derive(Debug, Clone, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
+#[derive(Debug, Clone, Copy, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
 pub enum PublishCategory {
     /// Series is being serialized
     Serializing = 1,
     /// Series is complete!
     Complete = 2,
+    /// ???
     ReadingOut = 3,
 }
 
@@ -114,6 +118,7 @@ pub enum PublishCategory {
 #[derive(
     Debug,
     Clone,
+    Copy,
     SerializeEnum32,
     DeserializeEnum32Fallback,
     PartialEq,
@@ -291,7 +296,7 @@ impl MagazineCategory {
 }
 
 /// The favorite status of the titles.
-#[derive(Debug, Clone, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
+#[derive(Debug, Clone, Copy, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
 pub enum FavoriteStatus {
     /// Title is not favorited.
     None = 0,
@@ -302,7 +307,7 @@ pub enum FavoriteStatus {
 }
 
 /// The support status of the titles.
-#[derive(Debug, Clone, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
+#[derive(Debug, Clone, Copy, SerializeEnum32, DeserializeEnum32, PartialEq, EnumName)]
 pub enum SupportStatus {
     /// Not allowed to support the titles.
     NotAllowed = 0,

--- a/tosho_kmkc/src/models/enums.rs
+++ b/tosho_kmkc/src/models/enums.rs
@@ -5,7 +5,6 @@
 //! Especially for [`MagazineCategory`] enum as it needs to be manually documented/updated.
 
 use documented::DocumentedFields;
-use serde::{Deserialize, Serialize};
 use tosho_macros::{
     DeserializeEnum32, DeserializeEnum32Fallback, EnumCount, EnumName, EnumU32Fallback,
     SerializeEnum32,

--- a/tosho_kmkc/src/models/enums.rs
+++ b/tosho_kmkc/src/models/enums.rs
@@ -240,7 +240,7 @@ impl MagazineCategory {
     /// Get the pretty name of the magazine category.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_kmkc::models::MagazineCategory;
     ///
     /// let e_young = MagazineCategory::eYoungMagazine;

--- a/tosho_kmkc/src/models/episode.rs
+++ b/tosho_kmkc/src/models/episode.rs
@@ -4,41 +4,44 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tosho_macros::AutoGetter;
 
 use super::{EpisodeBadge, FavoriteStatus, IntBool, TitleShare};
 
 /// A node of a single episode's information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct EpisodeNode {
     /// The episode ID.
     #[serde(rename = "episode_id")]
-    pub id: i32,
+    id: i32,
     /// The episode title.
     #[serde(rename = "episode_name")]
-    pub title: String,
+    title: String,
     /// The episode index.
-    pub index: i32,
+    index: i32,
     /// The badge for the episode.
-    pub badge: EpisodeBadge,
+    #[copyable]
+    badge: EpisodeBadge,
     /// The episode purchase point.
-    pub point: i32,
+    point: i32,
     /// The episode bonus point that will be given if purchased/read.
-    pub bonus_point: i32,
+    bonus_point: i32,
     /// The episode use status.
-    /// TODO: Change to enum
-    pub use_status: i32,
+    use_status: i32, // TODO: Change to enum
     /// The episode ticket rental status.
     #[serde(rename = "ticket_rental_enabled")]
-    pub ticket_rental: IntBool,
+    #[copyable]
+    ticket_rental: IntBool,
     /// The title ID associated with the episode.
-    pub title_id: i32,
+    title_id: i32,
     /// The episode start time or release time.
     #[serde(with = "super::datetime")]
-    pub start_time: DateTime<Utc>,
+    #[copyable]
+    start_time: DateTime<Utc>,
     /// The episosde rental rest time.
-    pub rental_rest_time: Option<String>,
+    rental_rest_time: Option<String>,
     /// Magazine ID associated with the episode.
-    pub magazine_id: Option<i32>,
+    magazine_id: Option<i32>,
 }
 
 impl EpisodeNode {
@@ -59,37 +62,28 @@ impl EpisodeNode {
 }
 
 /// Represents the episode list response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct EpisodesListResponse {
     /// The list of episodes.
     #[serde(rename = "episode_list")]
-    pub episodes: Vec<EpisodeNode>,
+    episodes: Vec<EpisodeNode>,
 }
 
 /// The node of a single image page.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ImagePageNode {
     /// Image index
-    pub index: i32,
+    index: i32,
     /// Image URL
     #[serde(rename = "image_url")]
-    pub url: String,
+    url: String,
 }
 
 impl ImagePageNode {
     /// The file name of the image.
     ///
-    /// # Examples
-    /// ```rust
-    /// use tosho_kmkc::models::ImagePageNode;
-    ///
-    /// let page = ImagePageNode {
-    ///     index: 0,
-    ///     url: "https://example.com/image.jpg?test=ignore".to_string(),
-    /// };
-    ///
-    /// assert_eq!(page.file_name(), "image.jpg");
-    /// ```
+    /// When you have the URL of `https://example.com/image.jpg?ignore=me`,
+    /// the filename would become `image.jpg` including the extension.
     pub fn file_name(&self) -> String {
         let url = self.url.as_str();
         match url.rfind('/') {
@@ -108,17 +102,9 @@ impl ImagePageNode {
 
     /// The file extension of the image.
     ///
-    /// # Examples
-    /// ```rust
-    /// use tosho_kmkc::models::ImagePageNode;
-    ///
-    /// let page = ImagePageNode {
-    ///     index: 0,
-    ///     url: "https://example.com/image.jpg?test=ignore".to_string(),
-    /// };
-    ///
-    /// assert_eq!(page.extension(), "jpg");
-    /// ```
+    /// When you have the URL of `https://example.com/image.jpg?ignore=me`,
+    /// the extension would become `jpg`, when there is no extension it
+    /// would return an empty string.
     pub fn extension(&self) -> String {
         let file_name = self.file_name();
         let split: Vec<&str> = file_name.rsplitn(2, '.').collect();
@@ -132,17 +118,8 @@ impl ImagePageNode {
 
     /// The file stem of the image.
     ///
-    /// # Examples
-    /// ```rust
-    /// use tosho_kmkc::models::ImagePageNode;
-    ///
-    /// let page = ImagePageNode {
-    ///     index: 0,
-    ///     url: "https://example.com/image.jpg?test=ignore".to_string(),
-    /// };
-    ///
-    /// assert_eq!(page.file_stem(), "image");
-    /// ```
+    /// When you have the URL of `https://example.com/image.jpg?ignore=me`,
+    /// the file stem would become `image`.
     pub fn file_stem(&self) -> String {
         let file_name = self.file_name();
         let split: Vec<&str> = file_name.rsplitn(2, '.').collect();
@@ -177,6 +154,15 @@ impl From<ImagePageNodeStr> for ImagePageNode {
         Self {
             index: 0,
             url: value.0,
+        }
+    }
+}
+
+impl From<&ImagePageNodeStr> for ImagePageNode {
+    fn from(value: &ImagePageNodeStr) -> Self {
+        Self {
+            index: 0,
+            url: value.0.clone(),
         }
     }
 }
@@ -229,40 +215,40 @@ impl ImagePageNodeStr {
 }
 
 /// Represents the episode view response for mobile viewer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MobileEpisodeViewerResponse {
     /// The episode ID.
     #[serde(rename = "episode_id")]
-    pub id: i32,
+    id: i32,
     /// The list of pages.
     #[serde(rename = "page_list")]
-    pub pages: Vec<ImagePageNode>,
+    pages: Vec<ImagePageNode>,
     /// The list of episodes for this titles.
     #[serde(rename = "episode_list")]
-    pub episodes: Vec<EpisodeNode>,
+    episodes: Vec<EpisodeNode>,
     /// The next episode ID.
     #[serde(rename = "next_episode_id", default)]
-    pub next_id: Option<i32>,
+    next_id: Option<i32>,
     /// The previous episode ID.
     #[serde(rename = "prev_episode_id", default)]
-    pub prev_id: Option<i32>,
+    prev_id: Option<i32>,
 }
 
 /// Represents the episode view response for web viewer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct WebEpisodeViewerResponse {
     /// The episode ID.
     #[serde(rename = "episode_id")]
-    pub id: i32,
+    id: i32,
     /// The list of pages.
     #[serde(rename = "page_list")]
-    pub pages: Vec<ImagePageNodeStr>,
+    pages: Vec<ImagePageNodeStr>,
     /// The bonus point of the episode.
-    pub bonus_point: i32,
+    bonus_point: i32,
     /// The title ID associated with the episode.
-    pub title_id: i32,
+    title_id: i32,
     /// The scramble seed for the epsiode
-    pub scramble_seed: u32,
+    scramble_seed: u32,
 }
 
 /// Represents the episode view response.
@@ -277,47 +263,48 @@ pub enum EpisodeViewerResponse {
 }
 
 /// Represents an episode purchase response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize)]
 pub struct EpisodePurchaseResponse {
     /// The point left on the account
     #[serde(rename = "account_point")]
-    pub left: i32,
+    left: i32,
     /// The point paid for the episode
     #[serde(rename = "paid_point")]
-    pub paid: i32,
+    paid: i32,
 }
 
 /// Represents a bulk episode purchase response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize)]
 pub struct BulkEpisodePurchaseResponse {
     /// The point left on the account
     #[serde(rename = "account_point")]
-    pub left: i32,
+    left: i32,
     /// The point paid for the episode
     #[serde(rename = "paid_point")]
-    pub paid: i32,
+    paid: i32,
     /// The point earned back from the purchase
     #[serde(rename = "earned_point_back")]
-    pub point_back: i32,
+    point_back: i32,
 }
 
 /// Represents an episode finish response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct EpisodeViewerFinishResponse {
     /// The ID of the episode.
     #[serde(rename = "episode_id")]
-    pub id: u32,
+    id: u32,
     /// The title ID of the episode.
-    pub title_id: i32,
+    title_id: i32,
     /// The favorite status of the titles.
     #[serde(rename = "favorite_status")]
-    pub favorite: FavoriteStatus,
+    #[copyable]
+    favorite: FavoriteStatus,
     /// The bonus point of the episode.
-    pub bonus_point: i32,
+    bonus_point: i32,
     /// The bonus point of the episode.
     #[serde(rename = "view_finish_episode_count")]
-    pub view_count: u64,
+    view_count: u64,
     /// Episode or title SNS sharing information
     #[serde(rename = "title_share_ret")]
-    pub share: TitleShare,
+    share: TitleShare,
 }

--- a/tosho_kmkc/src/models/episode.rs
+++ b/tosho_kmkc/src/models/episode.rs
@@ -78,7 +78,7 @@ impl ImagePageNode {
     /// The file name of the image.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_kmkc::models::ImagePageNode;
     ///
     /// let page = ImagePageNode {
@@ -107,7 +107,7 @@ impl ImagePageNode {
     /// The file extension of the image.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_kmkc::models::ImagePageNode;
     ///
     /// let page = ImagePageNode {
@@ -131,7 +131,7 @@ impl ImagePageNode {
     /// The file stem of the image.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_kmkc::models::ImagePageNode;
     ///
     /// let page = ImagePageNode {
@@ -183,7 +183,7 @@ impl ImagePageNodeStr {
     /// The file name of the image.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_kmkc::models::ImagePageNodeStr;
     ///
     /// let page = ImagePageNodeStr("https://example.com/image.jpg?test=ignore".to_string());
@@ -198,7 +198,7 @@ impl ImagePageNodeStr {
     /// The file extension of the image.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_kmkc::models::ImagePageNodeStr;
     ///
     /// let page = ImagePageNodeStr("https://example.com/image.jpg?test=ignore".to_string());
@@ -213,7 +213,7 @@ impl ImagePageNodeStr {
     /// The file stem of the image.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_kmkc::models::ImagePageNodeStr;
     ///
     /// let page = ImagePageNodeStr("https://example.com/image.jpg?test=ignore".to_string());

--- a/tosho_kmkc/src/models/episode.rs
+++ b/tosho_kmkc/src/models/episode.rs
@@ -69,7 +69,9 @@ pub struct EpisodesListResponse {
 /// The node of a single image page.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImagePageNode {
+    /// Image index
     pub index: i32,
+    /// Image URL
     #[serde(rename = "image_url")]
     pub url: String,
 }
@@ -315,6 +317,7 @@ pub struct EpisodeViewerFinishResponse {
     /// The bonus point of the episode.
     #[serde(rename = "view_finish_episode_count")]
     pub view_count: u64,
+    /// Episode or title SNS sharing information
     #[serde(rename = "title_share_ret")]
     pub share: TitleShare,
 }

--- a/tosho_kmkc/src/models/errors.rs
+++ b/tosho_kmkc/src/models/errors.rs
@@ -28,6 +28,7 @@ impl std::error::Error for KMAPIError {}
 /// An error when you don't have enough point to buy a titles chapters.
 #[derive(Debug)]
 pub struct KMAPINotEnoughPointsError {
+    /// The error message
     pub message: String,
     /// The amount of points you need to buy the chapters.
     pub points_needed: u64,

--- a/tosho_kmkc/src/models/mod.rs
+++ b/tosho_kmkc/src/models/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
+#![warn(clippy::missing_docs_in_private_items)]
+
 pub mod account;
 pub mod common;
 mod datetime;

--- a/tosho_kmkc/src/models/other.rs
+++ b/tosho_kmkc/src/models/other.rs
@@ -3,98 +3,102 @@
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
 use serde::{Deserialize, Serialize};
+use tosho_macros::AutoGetter;
 
 use super::{IntBool, SimpleId, TitleNode};
 
 /// The weekly list contents
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct WeeklyListContent {
     /// The weekday index (1-7)
     #[serde(rename = "weekday_index")]
-    pub weekday: i32,
+    weekday: i32,
     /// The list of titles.
     #[serde(rename = "title_id_list")]
-    pub titles: Vec<i32>,
+    titles: Vec<i32>,
     /// The featured title ID.
     #[serde(rename = "feature_title_id")]
-    pub featured_id: i32,
+    featured_id: i32,
     /// The list of title with bonus point.
     #[serde(rename = "bonus_point_title_id")]
-    pub bonus_titles: Vec<i32>,
+    bonus_titles: Vec<i32>,
     /// The list of popular titles.
     #[serde(rename = "popular_title_id_list")]
-    pub popular_titles: Vec<i32>,
+    popular_titles: Vec<i32>,
     /// The list of new titles.
     #[serde(rename = "new_title_id_list")]
-    pub new_titles: Vec<i32>,
+    new_titles: Vec<i32>,
 }
 
 /// Represents the weekly list response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct WeeklyListResponse {
     /// The list of weekly list contents.
     #[serde(rename = "weekly_list")]
-    pub contents: Vec<WeeklyListContent>,
+    contents: Vec<WeeklyListContent>,
     /// The list of titles associated with the weekly list.
     #[serde(rename = "title_list")]
-    pub titles: Vec<TitleNode>,
+    titles: Vec<TitleNode>,
 }
 
 /// Magazine category information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MagazineCategoryInfo {
     /// The magazine category ID.
     #[serde(rename = "magazine_category_id")]
-    pub id: u32,
+    id: u32,
     /// The magazine category name.
     #[serde(rename = "magazine_category_name_text")]
-    pub name: String,
+    name: String,
     /// Whether the magazine is purchased or not.
     #[serde(rename = "is_purchase")]
-    pub purchased: IntBool,
+    #[copyable]
+    purchased: IntBool,
     /// Whether the magazine is searchable or not.
     #[serde(rename = "is_search")]
-    pub searchable: IntBool,
+    #[copyable]
+    searchable: IntBool,
     /// Whether the magazine is subscribable or not.
     #[serde(rename = "is_subscription")]
-    pub subscribable: IntBool,
+    #[copyable]
+    subscribable: IntBool,
     /// The image URL of the magazine category.
     #[serde(rename = "subscription_image_url", default)]
-    pub image_url: Option<String>,
+    image_url: Option<String>,
 }
 
 /// Represents the magazine category response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MagazineCategoryResponse {
     /// The list of magazine categories.
     #[serde(rename = "magazine_category_list")]
-    pub categories: Vec<MagazineCategoryInfo>,
+    categories: Vec<MagazineCategoryInfo>,
 }
 
 /// A genre node
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct GenreNode {
     /// The genre ID.
     #[serde(rename = "genre_id")]
-    pub id: i32,
+    id: i32,
     /// The genre name.
     #[serde(rename = "genre_name")]
-    pub name: String,
+    name: String,
     /// The genre image URL.
-    pub image_url: String,
+    image_url: String,
 }
 
 /// Represents the genre search response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct GenreSearchResponse {
     /// The list of genres.
     #[serde(rename = "genre_list")]
-    pub genres: Vec<GenreNode>,
+    genres: Vec<GenreNode>,
 }
 
 /// Represents a ranking list response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct RankingListResponse {
     /// The list of titles.
-    pub titles: Vec<SimpleId>,
+    titles: Vec<SimpleId>,
 }

--- a/tosho_kmkc/src/models/titles.rs
+++ b/tosho_kmkc/src/models/titles.rs
@@ -4,147 +4,152 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tosho_macros::AutoGetter;
 
 use super::{FavoriteStatus, MagazineCategory, PublishCategory, SupportStatus};
 
 /// A single title's information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct TitleNode {
     /// The title ID.
     #[serde(rename = "title_id")]
-    pub id: i32,
+    id: i32,
     /// The title name.
     #[serde(rename = "title_name")]
-    pub title: String,
+    title: String,
     /// The title thumbnail URL.
     #[serde(rename = "thumbnail_image_url")]
-    pub thumbnail_url: String,
+    thumbnail_url: String,
     /// The title square thumbnail URL.
     #[serde(rename = "thumbnail_rect_image_url")]
-    pub square_thumbnail_url: String,
+    square_thumbnail_url: String,
     /// The title feature/banner image URL
     #[serde(rename = "feature_image_url")]
-    pub banner_url: String,
+    banner_url: String,
     /// The current active campaign text.
-    pub campaign_text: String,
+    campaign_text: String,
     /// The current notice for the title.
     #[serde(rename = "notice_text")]
-    pub notice: String,
+    notice: String,
     /// The first episode ID.
-    pub first_episode_id: i32,
+    first_episode_id: i32,
     /// The next update text for the title.
     #[serde(rename = "next_updated_text")]
-    pub next_update: Option<String>,
+    next_update: Option<String>,
     /// The author of the title.
     #[serde(rename = "author_text")]
-    pub author: String,
+    author: String,
     /// The authors of the title.
-    pub author_list: Vec<String>,
+    author_list: Vec<String>,
     /// The title's description.
     #[serde(rename = "introduction_text")]
-    pub description: String,
+    description: String,
     /// The title's summary or tagline
     #[serde(rename = "short_introduction_text")]
-    pub summary: String,
+    summary: String,
     /// The update cycle for when new episodes are released.
     #[serde(rename = "new_episode_update_cycle_text")]
-    pub update_cycle: String,
+    update_cycle: String,
     /// The update cycle for when new free episodes are released.
     #[serde(rename = "free_episode_update_cycle_text")]
-    pub free_update_cycle: String,
+    free_update_cycle: String,
     /// The order of the episode
-    pub episode_order: i32,
+    episode_order: i32,
     /// The list of episode IDs.
     #[serde(rename = "episode_id_list")]
-    pub episode_ids: Vec<i32>,
+    episode_ids: Vec<i32>,
     /// The latest paid episode ID.
     #[serde(rename = "latest_paid_episode_id")]
-    pub latest_episode_ids: Vec<i32>,
+    latest_episode_ids: Vec<i32>,
     /// The latest free episode ID.
-    pub latest_free_episode_id: Option<i32>,
+    latest_free_episode_id: Option<i32>,
     /// The list of genre IDs.
     #[serde(rename = "genre_id_list")]
-    pub genre_ids: Vec<i32>,
+    genre_ids: Vec<i32>,
     /// The favorite status of the titles.
     #[serde(rename = "favorite_status")]
-    pub favorite: FavoriteStatus,
+    #[copyable]
+    favorite: FavoriteStatus,
     /// The support status of the title.
     #[serde(rename = "support_status")]
-    pub support: SupportStatus,
+    #[copyable]
+    support: SupportStatus,
     /// The publish category of the title.
     #[serde(rename = "publish_category")]
-    pub publishing: PublishCategory,
+    #[copyable]
+    publishing: PublishCategory,
     /// The magazine category of the title.
     #[serde(rename = "magazine_category", default)]
-    pub magazine: MagazineCategory,
+    #[copyable]
+    magazine: MagazineCategory,
 }
 
 /// Represents the title list response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct TitleListResponse {
     /// The list of titles.
     #[serde(rename = "title_list")]
-    pub titles: Vec<TitleNode>,
+    titles: Vec<TitleNode>,
 }
 
 /// Represents a search response results
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct SearchResponse {
     /// The list of titles.
     #[serde(rename = "title_list")]
-    pub titles: Vec<TitleNode>,
+    titles: Vec<TitleNode>,
     /// The list of title IDs.
     #[serde(rename = "title_id_list")]
-    pub title_ids: Vec<i32>,
+    title_ids: Vec<i32>,
 }
 
 /// The premium ticket of a title
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize)]
 pub struct PremiumTicketInfo {
     /// The number of owned premium tickets.
     #[serde(rename = "own_ticket_num")]
-    pub owned: u64,
+    owned: u64,
     /// The type of premium ticket.
     /// Using integer instead of enum because it does not have enough information.
     #[serde(rename = "ticket_type")]
-    pub r#type: i32,
+    r#type: i32,
     /// The rental time of the premium ticket in seconds.
     #[serde(rename = "rental_second")]
-    pub duration: i32,
+    duration: i32,
 }
 
 /// The title ticket of a title
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize)]
 pub struct TitleTicketInfo {
     /// The number of owned title tickets.
     #[serde(rename = "own_ticket_num")]
-    pub owned: u64,
+    owned: u64,
     /// The rental time of the title ticket in seconds.
     #[serde(rename = "rental_second")]
-    pub duration: i32,
+    duration: i32,
     /// The type of title ticket.
     /// Using integer instead of enum because it does not have enough information.
     #[serde(rename = "ticket_type")]
-    pub r#type: i32,
+    r#type: i32,
     /// The ticket vversion of the title ticket.
     #[serde(rename = "ticket_version")]
-    pub version: i32,
+    version: i32,
     /// The maximum title ticket you can own
     #[serde(rename = "max_ticket_num")]
-    pub max_owned: u64,
+    max_owned: u64,
     /// The recover time left of the title ticket.
     #[serde(rename = "recover_second")]
-    pub recover_time: i32,
+    recover_time: i32,
     /// The end time of the title ticket, if used.
     #[serde(rename = "finish_time")]
-    pub end_time: Option<i32>,
+    end_time: Option<i32>,
     /// The next ticket recover time left of the title ticket.
     #[serde(rename = "next_ticket_recover_second")]
-    pub next_recover_time: i32,
+    next_recover_time: i32,
 }
 
 /// A ticket info for a title (either premium or title ticket).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum TicketInfoType {
     /// The premium ticket info.
     Premium(PremiumTicketInfo),
@@ -153,28 +158,30 @@ pub enum TicketInfoType {
 }
 
 /// A ticket info for a title.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct TicketInfo {
     /// The premium ticket info.
     #[serde(rename = "premium_ticket_info")]
-    pub premium: Option<PremiumTicketInfo>,
+    #[copyable]
+    premium: Option<PremiumTicketInfo>,
     /// The title ticket info.
     #[serde(rename = "title_ticket_info")]
-    pub title: Option<TitleTicketInfo>,
+    #[copyable]
+    title: Option<TitleTicketInfo>,
     /// The list of applicable title IDs.
     #[serde(rename = "target_episode_id_list")]
-    pub title_ids: Option<Vec<i32>>,
+    title_ids: Option<Vec<i32>>,
 }
 
 /// The title ticket list entry of a title.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct TitleTicketListNode {
     /// The title ID.
     #[serde(rename = "title_id")]
-    pub id: i32,
+    id: i32,
     /// The ticket info
     #[serde(rename = "ticket_info")]
-    pub info: TicketInfo,
+    info: TicketInfo,
 }
 
 impl TitleTicketListNode {
@@ -215,96 +222,99 @@ impl TitleTicketListNode {
 }
 
 /// Represents the title ticket list response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct TitleTicketListResponse {
     /// The list of title ticket list entries.
     #[serde(rename = "title_ticket_list")]
-    pub tickets: Vec<TitleTicketListNode>,
+    tickets: Vec<TitleTicketListNode>,
 }
 
 /// A title node from a title purchase response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct TitlePurchaseNode {
     /// The title ID.
     #[serde(rename = "title_id")]
-    pub id: i32,
+    id: i32,
     /// The title name.
     #[serde(rename = "title_name")]
-    pub title: String,
+    title: String,
     /// The title thumbnail URL.
     #[serde(rename = "thumbnail_image_url")]
-    pub thumbnail_url: String,
+    thumbnail_url: String,
     /// The first episode ID.
-    pub first_episode_id: i32,
+    first_episode_id: i32,
     /// The ID of the recently purchased episode.
     #[serde(rename = "recently_purchased_episode_id")]
-    pub recent_purchase_id: i32,
+    recent_purchase_id: i32,
 }
 
 /// Represents the title purchase response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct TitlePurchaseResponse {
     /// The list of title nodes.
     #[serde(rename = "title_list")]
-    pub titles: Vec<TitlePurchaseNode>,
+    titles: Vec<TitlePurchaseNode>,
 }
 
 /// Title sharing data
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct TitleShare {
     /// The title name.
     #[serde(rename = "title_name")]
-    pub title: String,
+    title: String,
     /// The title social media post text.
     #[serde(rename = "twitter_post_text")]
-    pub post_text: String,
+    post_text: String,
     /// The share URL.
-    pub url: String,
+    url: String,
 }
 
 /// Favorite title node
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize)]
 pub struct TitleFavoriteNode {
     /// The title ID.
     #[serde(rename = "title_id")]
-    pub id: i32,
+    id: i32,
     /// The update cycle for when new episodes are released.
     #[serde(
         rename = "paid_episode_updated",
         serialize_with = "super::datetime::serialize_opt",
         deserialize_with = "super::datetime::deserialize_opt"
     )]
-    pub update_cycle: Option<DateTime<Utc>>,
+    #[copyable]
+    update_cycle: Option<DateTime<Utc>>,
     /// The update cycle for when new free episodes are released.
     #[serde(
         rename = "free_episode_updated",
         serialize_with = "super::datetime::serialize_opt",
         deserialize_with = "super::datetime::deserialize_opt"
     )]
-    pub free_update_cycle: Option<DateTime<Utc>>,
+    #[copyable]
+    free_update_cycle: Option<DateTime<Utc>>,
     /// The title purchase status.
-    pub purchase_status: i32,
+    purchase_status: i32,
     /// The title ticket recover time.
     #[serde(
         serialize_with = "super::datetime::serialize_opt",
         deserialize_with = "super::datetime::deserialize_opt"
     )]
-    pub ticket_recover_time: Option<DateTime<Utc>>,
+    #[copyable]
+    ticket_recover_time: Option<DateTime<Utc>>,
 }
 
 /// Represents the user favorite title list response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct TitleFavoriteResponse {
     /// The list of favorite title nodes.
     #[serde(rename = "favorite_title_list")]
-    pub favorites: Vec<TitleFavoriteNode>,
+    favorites: Vec<TitleFavoriteNode>,
     /// The list of title nodes.
     #[serde(rename = "title_list")]
-    pub titles: Vec<TitleNode>,
+    titles: Vec<TitleNode>,
     /// Favorite count
     #[serde(rename = "favorite_num")]
-    pub count: u64,
+    count: u64,
     /// Maximum favorite count
     #[serde(rename = "max_favorite_num")]
-    pub max_count: u64,
+    max_count: u64,
 }

--- a/tosho_kmkc/src/models/titles.rs
+++ b/tosho_kmkc/src/models/titles.rs
@@ -87,6 +87,7 @@ pub struct TitleListResponse {
     pub titles: Vec<TitleNode>,
 }
 
+/// Represents a search response results
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchResponse {
     /// The list of titles.

--- a/tosho_kmkc/src/models/titles.rs
+++ b/tosho_kmkc/src/models/titles.rs
@@ -271,6 +271,7 @@ pub struct TitleShare {
 
 /// Favorite title node
 #[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize)]
+#[auto_getters(unref = true)]
 pub struct TitleFavoriteNode {
     /// The title ID.
     #[serde(rename = "title_id")]
@@ -281,7 +282,6 @@ pub struct TitleFavoriteNode {
         serialize_with = "super::datetime::serialize_opt",
         deserialize_with = "super::datetime::deserialize_opt"
     )]
-    #[copyable]
     update_cycle: Option<DateTime<Utc>>,
     /// The update cycle for when new free episodes are released.
     #[serde(
@@ -289,7 +289,6 @@ pub struct TitleFavoriteNode {
         serialize_with = "super::datetime::serialize_opt",
         deserialize_with = "super::datetime::deserialize_opt"
     )]
-    #[copyable]
     free_update_cycle: Option<DateTime<Utc>>,
     /// The title purchase status.
     purchase_status: i32,
@@ -298,7 +297,6 @@ pub struct TitleFavoriteNode {
         serialize_with = "super::datetime::serialize_opt",
         deserialize_with = "super::datetime::deserialize_opt"
     )]
-    #[copyable]
     ticket_recover_time: Option<DateTime<Utc>>,
 }
 

--- a/tosho_macros/Cargo.toml
+++ b/tosho_macros/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 [dependencies]
 syn = "2.0"
 quote = "1.0"
+proc-macro2 = "1.0"
 
 [dev-dependencies]
 serde.workspace = true

--- a/tosho_macros/src/deser.rs
+++ b/tosho_macros/src/deser.rs
@@ -1,3 +1,5 @@
+//! A implementation collection of some ser/de stuff
+
 use proc_macro::TokenStream;
 
 pub(crate) fn impl_serenum_derive(ast: &syn::DeriveInput) -> TokenStream {
@@ -8,7 +10,7 @@ pub(crate) fn impl_serenum_derive(ast: &syn::DeriveInput) -> TokenStream {
     };
 
     let tokens = quote::quote! {
-        impl Serialize for #name {
+        impl serde::Serialize for #name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: serde::Serializer,
@@ -28,7 +30,7 @@ pub(crate) fn impl_deserenum_derive(ast: &syn::DeriveInput) -> TokenStream {
     };
 
     let tokens = quote::quote! {
-        impl<'de> Deserialize<'de> for #name {
+        impl<'de> serde::Deserialize<'de> for #name {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
                 D: serde::Deserializer<'de>,

--- a/tosho_macros/src/deser.rs
+++ b/tosho_macros/src/deser.rs
@@ -67,7 +67,7 @@ pub(crate) fn impl_serenum32_derive(ast: &syn::DeriveInput) -> TokenStream {
     }
 
     let tokens = quote::quote! {
-        impl Serialize for #name {
+        impl serde::Serialize for #name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: serde::Serializer,
@@ -119,7 +119,7 @@ pub(crate) fn impl_deserenum32_derive(ast: &syn::DeriveInput, with_default: bool
     }
 
     let tokens = quote::quote! {
-        impl<'de> Deserialize<'de> for #name {
+        impl<'de> serde::Deserialize<'de> for #name {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
                 D: serde::Deserializer<'de>,

--- a/tosho_macros/src/enums.rs
+++ b/tosho_macros/src/enums.rs
@@ -1,3 +1,5 @@
+//! A implementation collection of Enum related derive and expansion
+
 use proc_macro::TokenStream;
 
 pub(crate) fn impl_enumname_derive(ast: &syn::DeriveInput) -> TokenStream {

--- a/tosho_macros/src/lib.rs
+++ b/tosho_macros/src/lib.rs
@@ -1,10 +1,5 @@
-//! # tosho-macros
-//!
-//! A collection of macros used by [`tosho`](https://github.com/noaione/tosho-mango) and the other sources crates.
-//!
-//! ## License
-//!
-//! This project is licensed with MIT License ([LICENSE](https://github.com/noaione/tosho-mango/blob/master/LICENSE) or <http://opensource.org/licenses/MIT>)
+#![warn(missing_docs, clippy::empty_docs, rustdoc::broken_intra_doc_links)]
+#![doc = include_str!("../README.md")]
 
 use proc_macro::TokenStream;
 

--- a/tosho_macros/src/lib.rs
+++ b/tosho_macros/src/lib.rs
@@ -10,14 +10,14 @@ use proc_macro::TokenStream;
 
 mod deser;
 mod enums;
+mod structs;
 
 /// Derives [`serde::Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html) for an enum using [`std::fmt::Display`]
 ///
 /// # Example
 /// ```
-/// use serde::Serialize;
-/// use tosho_macros::SerializeEnum;
-///
+/// # use tosho_macros::SerializeEnum;
+/// #
 /// #[derive(SerializeEnum)]
 /// enum TestEnum {
 ///     Create,
@@ -46,9 +46,8 @@ pub fn serializenum_derive(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 /// ```
-/// use serde::Deserialize;
-/// use tosho_macros::DeserializeEnum;
-///
+/// # use tosho_macros::DeserializeEnum;
+/// #
 /// #[derive(DeserializeEnum, PartialEq, Eq, Debug)]
 /// enum TestEnum {
 ///     Create,
@@ -84,9 +83,8 @@ pub fn deserializeenum_derive(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 /// ```
-/// use serde::Serialize;
-/// use tosho_macros::SerializeEnum32;
-///
+/// # use tosho_macros::SerializeEnum32;
+/// #
 /// #[derive(SerializeEnum32)]
 /// enum TestEnum {
 ///     Create = 0,
@@ -103,9 +101,8 @@ pub fn serializenum32_derive(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 /// ```
-/// use serde::Deserialize;
-/// use tosho_macros::DeserializeEnum32;
-///
+/// # use tosho_macros::DeserializeEnum32;
+/// #
 /// #[derive(DeserializeEnum32)]
 /// enum TestEnum {
 ///     Create = 0,
@@ -122,9 +119,8 @@ pub fn deserializeenum32_derive(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 /// ```
-/// use serde::Deserialize;
-/// use tosho_macros::DeserializeEnum32Fallback;
-///
+/// # use tosho_macros::DeserializeEnum32Fallback;
+/// #
 /// #[derive(DeserializeEnum32Fallback, Default)]
 /// enum TestEnum {
 ///     #[default]
@@ -143,8 +139,8 @@ pub fn deserializeenum32fallback_derive(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 /// ```
-/// use tosho_macros::EnumName;
-///
+/// # use tosho_macros::EnumName;
+/// #
 /// #[derive(EnumName, Clone, Debug)]
 /// enum TestEnum {
 ///     Create,
@@ -164,8 +160,8 @@ pub fn enumname_derive(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 /// ```
-/// use tosho_macros::EnumCount;
-///
+/// # use tosho_macros::EnumCount;
+/// #
 /// #[derive(EnumCount, Clone, Debug)]
 /// enum TestEnum {
 ///     Create,
@@ -212,4 +208,35 @@ pub fn enumu32fallback_derive(input: TokenStream) -> TokenStream {
 pub fn enum_error(item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as enums::EnumErrorMacroInput);
     enums::impl_enum_error(&input)
+}
+
+/// Derive the `AutoGetter` macro for a struct
+///
+/// Automatically expand each field into their own getter function for all private field.
+///
+/// # Examples
+/// ```rust
+/// # use tosho_macros::AutoGetter;
+/// #
+/// #[derive(AutoGetter)]
+/// pub struct Data {
+///     #[copyable]
+///     id: i64,
+///     username: String,
+/// }
+///
+/// # fn main() {
+/// let data = Data { id: 1, username: "test".to_string() };
+///
+/// assert_eq!(data.id(), 1);
+/// assert_eq!(data.username(), "test");
+/// # }
+/// ```
+#[proc_macro_derive(AutoGetter, attributes(auto_getters, copyable))]
+pub fn autogetter_derive(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    // Generate the implementation of the trait
+    structs::impl_autogetter(&input)
 }

--- a/tosho_macros/src/lib.rs
+++ b/tosho_macros/src/lib.rs
@@ -15,7 +15,7 @@ mod structs;
 /// Derives [`serde::Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html) for an enum using [`std::fmt::Display`]
 ///
 /// # Example
-/// ```
+/// ```rust
 /// # use tosho_macros::SerializeEnum;
 /// #
 /// #[derive(SerializeEnum)]
@@ -45,7 +45,7 @@ pub fn serializenum_derive(input: TokenStream) -> TokenStream {
 /// Derives [`serde::Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) for an enum using [`std::str::FromStr`]
 ///
 /// # Example
-/// ```
+/// ```rust
 /// # use tosho_macros::DeserializeEnum;
 /// #
 /// #[derive(DeserializeEnum, PartialEq, Eq, Debug)]
@@ -82,7 +82,7 @@ pub fn deserializeenum_derive(input: TokenStream) -> TokenStream {
 /// Derives [`serde::Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html) for an enum in i32 mode.
 ///
 /// # Example
-/// ```
+/// ```rust
 /// # use tosho_macros::SerializeEnum32;
 /// #
 /// #[derive(SerializeEnum32)]
@@ -100,7 +100,7 @@ pub fn serializenum32_derive(input: TokenStream) -> TokenStream {
 /// Derives [`serde::Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) for an enum in i32 mode.
 ///
 /// # Example
-/// ```
+/// ```rust
 /// # use tosho_macros::DeserializeEnum32;
 /// #
 /// #[derive(DeserializeEnum32)]
@@ -118,7 +118,7 @@ pub fn deserializeenum32_derive(input: TokenStream) -> TokenStream {
 /// Derives [`serde::Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) for an enum in i32 mode with fallback to [`std::default::Default`].
 ///
 /// # Example
-/// ```
+/// ```rust
 /// # use tosho_macros::DeserializeEnum32Fallback;
 /// #
 /// #[derive(DeserializeEnum32Fallback, Default)]
@@ -138,7 +138,7 @@ pub fn deserializeenum32fallback_derive(input: TokenStream) -> TokenStream {
 /// Derives an enum that would implement `.to_name()`
 ///
 /// # Example
-/// ```
+/// ```rust
 /// # use tosho_macros::EnumName;
 /// #
 /// #[derive(EnumName, Clone, Debug)]
@@ -159,7 +159,7 @@ pub fn enumname_derive(input: TokenStream) -> TokenStream {
 /// Derives an enum that would implement `::count()` to return the number of variants
 ///
 /// # Example
-/// ```
+/// ```rust
 /// # use tosho_macros::EnumCount;
 /// #
 /// #[derive(EnumCount, Clone, Debug)]
@@ -194,7 +194,7 @@ pub fn enumu32fallback_derive(input: TokenStream) -> TokenStream {
 /// when using other macros to derive [`std::str::FromStr`] for an enum.
 ///
 /// # Example
-/// ```
+/// ```rust
 /// # use tosho_macros::enum_error;
 /// #
 /// enum TestEnum {

--- a/tosho_macros/src/lib.rs
+++ b/tosho_macros/src/lib.rs
@@ -223,16 +223,20 @@ pub fn enum_error(item: TokenStream) -> TokenStream {
 ///     #[copyable]
 ///     id: i64,
 ///     username: String,
+///     #[skip_field]
+///     pos: u32,
 /// }
 ///
 /// # fn main() {
-/// let data = Data { id: 1, username: "test".to_string() };
+/// let data = Data { id: 1, username: "test".to_string(), pos: 0 };
 ///
 /// assert_eq!(data.id(), 1);
 /// assert_eq!(data.username(), "test");
+/// // "pos" field doesn't have getter
+/// assert_eq!(data.pos, 0);
 /// # }
 /// ```
-#[proc_macro_derive(AutoGetter, attributes(auto_getters, copyable))]
+#[proc_macro_derive(AutoGetter, attributes(auto_getters, copyable, skip_field))]
 pub fn autogetter_derive(input: TokenStream) -> TokenStream {
     // Parse the input tokens into a syntax tree
     let input = syn::parse_macro_input!(input as syn::DeriveInput);

--- a/tosho_macros/src/lib.rs
+++ b/tosho_macros/src/lib.rs
@@ -231,7 +231,10 @@ pub fn enum_error(item: TokenStream) -> TokenStream {
 /// assert_eq!(data.pos, 0);
 /// # }
 /// ```
-#[proc_macro_derive(AutoGetter, attributes(auto_getters, copyable, skip_field))]
+#[proc_macro_derive(
+    AutoGetter,
+    attributes(auto_getters, copyable, skip_field, deref_clone)
+)]
 pub fn autogetter_derive(input: TokenStream) -> TokenStream {
     // Parse the input tokens into a syntax tree
     let input = syn::parse_macro_input!(input as syn::DeriveInput);

--- a/tosho_macros/src/structs.rs
+++ b/tosho_macros/src/structs.rs
@@ -129,8 +129,11 @@ pub(crate) fn impl_autogetter(ast: &syn::DeriveInput) -> TokenStream {
         getters.push(field);
     }
 
+    let generics = &ast.generics;
+    let (impl_gen, ty_gen, where_cl) = generics.split_for_impl();
+
     let expanded = quote::quote! {
-        impl #name {
+        impl #impl_gen #name #ty_gen #where_cl {
             #(#getters)*
         }
     };

--- a/tosho_macros/src/structs.rs
+++ b/tosho_macros/src/structs.rs
@@ -1,0 +1,292 @@
+//! An implementation collection for struct
+
+//! A custom derive collection macro for ClickHouse model data.
+
+use proc_macro::TokenStream;
+use quote::ToTokens;
+use syn::{punctuated::Punctuated, Attribute, Expr, Lit, Meta, Token};
+
+#[derive(Default, Clone, Copy)]
+struct AutoGetterAttr {
+    unref: bool,
+}
+
+fn get_autogetter_attr(attrs: Vec<Attribute>) -> Result<AutoGetterAttr, syn::Error> {
+    let mut unref = false;
+
+    for attr in &attrs {
+        if attr.path().is_ident("auto_getters") {
+            let nested = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
+
+            for meta in nested {
+                if let Meta::NameValue(nameval) = meta {
+                    if nameval.path.is_ident("unref") {
+                        // Is a boolean
+                        if let Expr::Lit(lit) = nameval.value {
+                            if let Lit::Bool(val) = lit.lit {
+                                unref = val.value;
+                            } else {
+                                return Err(syn::Error::new_spanned(
+                                    lit,
+                                    "Expected a boolean value for `unref`",
+                                ));
+                            }
+                        } else {
+                            return Err(syn::Error::new_spanned(
+                                nameval.value,
+                                "Expected a boolean value for `unref`",
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(AutoGetterAttr { unref })
+}
+
+/// The main function to expand the `AutoGetter` derive macro
+///
+/// # Examples
+/// ```
+/// #[derive(AutoGetter)]
+/// pub struct Model {
+///     id: String,
+///     username: String,
+/// }
+/// ```
+///
+/// Will generate
+///
+/// ```rust
+/// impl AutoGetter {
+///     pub fn id(&self) -> &str {
+///        &self.id
+///     }
+///
+///     pub fn username(&self) -> &str {
+///        &self.username
+///     }
+/// }
+/// ```
+///
+/// When the field use `Option` it will generate a getter that returns `Option<&T>`
+/// If setting, it will set the value to `Some(value)` with param of the `T`
+pub(crate) fn impl_autogetter(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    let (fields, attrs_config) = match &ast.data {
+        syn::Data::Struct(data) => match &data.fields {
+            syn::Fields::Named(fields) => match get_autogetter_attr(ast.attrs.clone()) {
+                Ok(attrs) => (fields, attrs),
+                Err(err) => return TokenStream::from(err.to_compile_error()),
+            },
+            _ => {
+                return TokenStream::from(
+                    syn::Error::new_spanned(
+                        ast,
+                        "Expected a struct with named fields for the `AutoGetter` derive macro",
+                    )
+                    .to_compile_error(),
+                );
+            }
+        },
+        _ => {
+            return TokenStream::from(
+                syn::Error::new_spanned(ast, "Expected a struct for the `AutoGetter` derive macro")
+                    .to_compile_error(),
+            );
+        }
+    };
+
+    let mut getters: Vec<proc_macro2::TokenStream> = Vec::new();
+
+    for field in fields.named.iter() {
+        let field_name = field.ident.as_ref().unwrap();
+        let field_ty = &field.ty;
+        let field_ty_name = field_ty.clone().into_token_stream().to_string();
+
+        let field = if field_ty_name.starts_with("Option") {
+            expand_option_field(field, field_name, attrs_config)
+        } else {
+            expand_regular_field(field, field_name, attrs_config)
+        };
+
+        getters.push(field);
+    }
+
+    let expanded = quote::quote! {
+        impl #name {
+            #(#getters)*
+        }
+    };
+
+    expanded.into()
+}
+
+fn expand_option_field(
+    field: &syn::Field,
+    field_name: &syn::Ident,
+    attrs_config: AutoGetterAttr,
+) -> proc_macro2::TokenStream {
+    let field_ty = &field.ty;
+    let field_ty_name = field_ty.clone().into_token_stream().to_string();
+
+    let doc_get = make_field_comment(field_name, true);
+
+    // If string, we can use as_deref
+    if field_ty_name.contains("String") {
+        let inner_ty = get_inner_type_of_option(field_ty).unwrap();
+        let has_vec = get_inner_type_of_vec(inner_ty).is_some();
+
+        if has_vec {
+            quote::quote! {
+                #[doc = #doc_get]
+                pub fn #field_name(&self) -> Option<&[String]> {
+                    self.#field_name.as_deref()
+                }
+            }
+        } else {
+            quote::quote! {
+                #[doc = #doc_get]
+                pub fn #field_name(&self) -> Option<&str> {
+                    self.#field_name.as_deref()
+                }
+            }
+        }
+    } else {
+        // Modify the field type to be a reference
+        let main_type = get_inner_type_of_option(field_ty).unwrap();
+        let copyable = has_copyable_ident(field);
+
+        let get_field = if copyable || attrs_config.unref {
+            quote::quote! {
+                #[doc = #doc_get]
+                pub fn #field_name(&self) -> Option<#main_type> {
+                    self.#field_name
+                }
+            }
+        } else if let Some(inner_ty) = get_inner_type_of_vec(main_type) {
+            quote::quote! {
+                #[doc = #doc_get]
+                pub fn #field_name(&self) -> Option<&[#inner_ty]> {
+                    self.#field_name.as_deref()
+                }
+            }
+        } else {
+            quote::quote! {
+                #[doc = #doc_get]
+                pub fn #field_name(&self) -> Option<&#main_type> {
+                    self.#field_name.as_ref()
+                }
+            }
+        };
+
+        // And the set ident to be just the field type without the Option
+        let getter = quote::quote! {
+            #get_field
+        };
+
+        getter
+    }
+}
+
+fn expand_regular_field(
+    field: &syn::Field,
+    field_name: &syn::Ident,
+    attrs_config: AutoGetterAttr,
+) -> proc_macro2::TokenStream {
+    let field_ty = &field.ty;
+    let field_ty_name = field_ty.clone().into_token_stream().to_string();
+
+    let doc_get = make_field_comment(field_name, false);
+
+    // If string, we can use as_deref
+    if field_ty_name.contains("String") {
+        let getter = quote::quote! {
+            #[doc = #doc_get]
+            pub fn #field_name(&self) -> &str {
+                &self.#field_name
+            }
+        };
+
+        getter
+    } else {
+        let event_copy = has_copyable_ident(field);
+
+        let get_field = if event_copy || attrs_config.unref {
+            quote::quote! {
+                #[doc = #doc_get]
+                pub fn #field_name(&self) -> #field_ty {
+                    self.#field_name
+                }
+            }
+        } else if let Some(inner_ty) = get_inner_type_of_vec(field_ty) {
+            quote::quote! {
+                #[doc = #doc_get]
+                pub fn #field_name(&self) -> &[#inner_ty] {
+                    &self.#field_name
+                }
+            }
+        } else {
+            quote::quote! {
+                #[doc = #doc_get]
+                pub fn #field_name(&self) -> &#field_ty {
+                    &self.#field_name
+                }
+            }
+        };
+
+        let getter = quote::quote! {
+            #get_field
+        };
+
+        getter
+    }
+}
+
+fn get_inner_type_of_x<'a>(ty: &'a syn::Type, x: &'a str) -> Option<&'a syn::Type> {
+    if let syn::Type::Path(type_path) = ty {
+        // Check if it's a path type, and the first segment of the path is "x"
+        if let Some(segment) = type_path.path.segments.first() {
+            if segment.ident == x {
+                // Check if the segment has generic arguments (i.e., x<T>)
+                if let syn::PathArguments::AngleBracketed(angle_bracketed) = &segment.arguments {
+                    // Get the first generic argument (T in x<T>)
+                    if let Some(syn::GenericArgument::Type(inner_type)) =
+                        angle_bracketed.args.first()
+                    {
+                        return Some(inner_type);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn get_inner_type_of_option(ty: &syn::Type) -> Option<&syn::Type> {
+    get_inner_type_of_x(ty, "Option")
+}
+
+fn get_inner_type_of_vec(ty: &syn::Type) -> Option<&syn::Type> {
+    get_inner_type_of_x(ty, "Vec")
+}
+
+fn has_copyable_ident(field: &syn::Field) -> bool {
+    field
+        .attrs
+        .iter()
+        .any(|attr| attr.path().is_ident("copyable"))
+}
+
+/// Generate field comment
+///
+/// If `option_mode` use the "if it exists" comment
+fn make_field_comment(field: &syn::Ident, option_mode: bool) -> String {
+    let if_it_exists = if option_mode { " if it exists" } else { "" };
+    let doc_get = format!("Get the value of `{}`{}", field, if_it_exists);
+
+    doc_get
+}

--- a/tosho_macros/src/structs.rs
+++ b/tosho_macros/src/structs.rs
@@ -212,14 +212,23 @@ fn expand_regular_field(
 
     // If string, we can use as_deref
     if field_ty_name.contains("String") {
-        let getter = quote::quote! {
-            #[doc = #doc_get]
-            pub fn #field_name(&self) -> &str {
-                &self.#field_name
-            }
-        };
+        let has_vec = has_inner_type_with_x(field_ty, "Vec");
 
-        getter
+        if has_vec {
+            quote::quote! {
+                #[doc = #doc_get]
+                pub fn #field_name(&self) -> &[String] {
+                    &self.#field_name
+                }
+            }
+        } else {
+            quote::quote! {
+                #[doc = #doc_get]
+                pub fn #field_name(&self) -> &str {
+                    &self.#field_name
+                }
+            }
+        }
     } else {
         let is_copyable = field_has_ident(field, "copyable") || is_copy_able_field(field_ty);
 

--- a/tosho_macros/src/structs.rs
+++ b/tosho_macros/src/structs.rs
@@ -54,7 +54,8 @@ fn get_autogetter_attr(attrs: Vec<Attribute>) -> Result<AutoGetterAttr, syn::Err
 /// The main function to expand the `AutoGetter` derive macro
 ///
 /// # Examples
-/// ```
+/// ```rust
+/// # use tosho_macros::AutoGetter;
 /// #[derive(AutoGetter)]
 /// pub struct Model {
 ///     id: String,
@@ -65,7 +66,11 @@ fn get_autogetter_attr(attrs: Vec<Attribute>) -> Result<AutoGetterAttr, syn::Err
 /// Will generate
 ///
 /// ```rust
-/// impl AutoGetter {
+/// # struct Model {
+/// #     id: String,
+/// #     username: String,
+/// # }
+/// impl Model {
 ///     pub fn id(&self) -> &str {
 ///        &self.id
 ///     }

--- a/tosho_mplus/src/constants.rs
+++ b/tosho_mplus/src/constants.rs
@@ -97,9 +97,9 @@ pub static IMAGE_HOST: LazyLock<String> = LazyLock::new(|| {
 /// Panics if the device type is invalid.
 ///
 /// # Examples
-/// ```
-/// use tosho_mplus::constants::get_constants;
-///
+/// ```rust
+/// # use tosho_mplus::constants::get_constants;
+/// #
 /// let _ = get_constants(1); // Android
 /// ```
 pub fn get_constants(device_type: u8) -> &'static Constants {

--- a/tosho_mplus/src/helper.rs
+++ b/tosho_mplus/src/helper.rs
@@ -8,8 +8,6 @@
 
 use std::str::FromStr;
 
-use serde::{Deserialize, Serialize};
-
 /// The image quality to be downloaded.
 #[derive(
     Debug, Clone, Copy, PartialEq, tosho_macros::SerializeEnum, tosho_macros::DeserializeEnum,

--- a/tosho_mplus/src/lib.rs
+++ b/tosho_mplus/src/lib.rs
@@ -1,3 +1,9 @@
+#![warn(
+    missing_docs,
+    clippy::empty_docs,
+    rustdoc::broken_intra_doc_links,
+    clippy::missing_docs_in_private_items
+)]
 #![doc = include_str!("../README.md")]
 
 pub mod constants;

--- a/tosho_mplus/src/lib.rs
+++ b/tosho_mplus/src/lib.rs
@@ -1,9 +1,3 @@
-#![warn(
-    missing_docs,
-    clippy::empty_docs,
-    rustdoc::broken_intra_doc_links,
-    clippy::missing_docs_in_private_items
-)]
 #![doc = include_str!("../README.md")]
 
 pub mod constants;

--- a/tosho_mplus/src/lib.rs
+++ b/tosho_mplus/src/lib.rs
@@ -53,7 +53,7 @@ impl MPClient {
     /// * `language` - The language to use for the client.
     /// * `constants` - The constants to use for the client.
     pub fn new(
-        secret: &str,
+        secret: impl Into<String>,
         language: Language,
         constants: &'static Constants,
     ) -> ToshoResult<Self> {
@@ -83,7 +83,7 @@ impl MPClient {
     }
 
     fn make_client(
-        secret: &str,
+        secret: impl Into<String>,
         language: Language,
         constants: &'static Constants,
         proxy: Option<reqwest::Proxy>,
@@ -111,7 +111,7 @@ impl MPClient {
 
         Ok(Self {
             inner: client,
-            secret: secret.to_string(),
+            secret: secret.into(),
             language,
             constants,
             app_ver: None,
@@ -529,9 +529,10 @@ impl MPClient {
     /// * `writer` - The writer to write the image to.
     pub async fn stream_download(
         &self,
-        url: &str,
+        url: impl Into<String>,
         mut writer: impl io::AsyncWrite + Unpin,
     ) -> ToshoResult<()> {
+        let url: String = url.into();
         let res = self
             .inner
             .get(url)

--- a/tosho_mplus/src/lib.rs
+++ b/tosho_mplus/src/lib.rs
@@ -172,8 +172,8 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.initial_view_v2 {
-                Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data.clone()))),
+            SuccessOrError::Success(data) => match data.initial_view_v2() {
+                Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
                 None => Err(ToshoParseError::expect("initial view")),
             },
             SuccessOrError::Error(error) => Ok(APIResponse::Error(error)),
@@ -195,7 +195,7 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.home_view_v3 {
+            SuccessOrError::Success(data) => match data.home_view_v3() {
                 Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
                 None => Err(ToshoParseError::expect("home view v3")),
             },
@@ -216,7 +216,7 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.user_profile_settings {
+            SuccessOrError::Success(data) => match data.user_profile_settings() {
                 Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
                 None => Err(ToshoParseError::expect("user profile settings")),
             },
@@ -239,7 +239,7 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.user_settings_v2 {
+            SuccessOrError::Success(data) => match data.user_settings_v2() {
                 Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
                 None => Err(ToshoParseError::expect("user settings v2")),
             },
@@ -259,7 +259,7 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.subscriptions {
+            SuccessOrError::Success(data) => match data.subscriptions() {
                 Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
                 None => Err(ToshoParseError::expect("subscriptions")),
             },
@@ -279,7 +279,7 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.all_titles_v2 {
+            SuccessOrError::Success(data) => match data.all_titles_v2() {
                 Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
                 None => Err(ToshoParseError::expect("all titles v2")),
             },
@@ -309,7 +309,7 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.title_ranking_v2 {
+            SuccessOrError::Success(data) => match data.title_ranking_v2() {
                 Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
                 None => Err(ToshoParseError::expect("title ranking v2")),
             },
@@ -329,7 +329,7 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.free_titles {
+            SuccessOrError::Success(data) => match data.free_titles() {
                 Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
                 None => Err(ToshoParseError::expect("free titles")),
             },
@@ -349,7 +349,7 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.subscribed_titles {
+            SuccessOrError::Success(data) => match data.subscribed_titles() {
                 Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
                 None => Err(ToshoParseError::expect("subscribed/bookmarked titles")),
             },
@@ -372,7 +372,7 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.search_results {
+            SuccessOrError::Success(data) => match data.search_results() {
                 Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
                 None => Err(ToshoParseError::expect("search results")),
             },
@@ -401,7 +401,7 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.title_detail {
+            SuccessOrError::Success(data) => match data.title_detail() {
                 Some(inner_data) => {
                     let mut cloned_data = inner_data.clone();
                     cloned_data.chapter_groups.iter_mut().for_each(|group| {
@@ -487,7 +487,7 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.chapter_viewer {
+            SuccessOrError::Success(data) => match data.chapter_viewer() {
                 Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
                 None => Err(ToshoParseError::expect("chapter viewer")),
             },
@@ -513,7 +513,7 @@ impl MPClient {
         let response = parse_response(request).await?;
 
         match response {
-            SuccessOrError::Success(data) => match data.comment_list {
+            SuccessOrError::Success(data) => match data.comment_list() {
                 Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
                 None => Err(ToshoParseError::expect("comment list")),
             },
@@ -600,7 +600,7 @@ async fn parse_response(res: reqwest::Response) -> ToshoResult<SuccessOrError> {
     let decoded_response = parse_protobuf_response::<crate::proto::Response>(res).await?;
 
     // oneof response on .response
-    match decoded_response.response {
+    match decoded_response.response() {
         Some(response) => Ok(response),
         None => Err(tosho_common::ToshoParseError::empty()),
     }

--- a/tosho_mplus/src/lib.rs
+++ b/tosho_mplus/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs, clippy::empty_docs, rustdoc::broken_intra_doc_links)]
 #![doc = include_str!("../README.md")]
 
 pub mod constants;
@@ -172,7 +173,7 @@ impl MPClient {
 
         match response {
             SuccessOrError::Success(data) => match data.initial_view_v2 {
-                Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data))),
+                Some(inner_data) => Ok(APIResponse::Success(Box::new(inner_data.clone()))),
                 None => Err(ToshoParseError::expect("initial view")),
             },
             SuccessOrError::Error(error) => Ok(APIResponse::Error(error)),
@@ -574,7 +575,9 @@ impl MPClient {
 ///
 /// It either returns the specified success response or an error.
 pub enum APIResponse<T: ::prost::Message + Clone> {
+    /// A [`Box`]-ed [`ErrorResponse`]
     Error(Box<ErrorResponse>),
+    /// Successfull response, also [`Box`]-ed and depends on the API call
     Success(Box<T>),
 }
 

--- a/tosho_mplus/src/lib.rs
+++ b/tosho_mplus/src/lib.rs
@@ -404,22 +404,25 @@ impl MPClient {
             SuccessOrError::Success(data) => match data.title_detail() {
                 Some(inner_data) => {
                     let mut cloned_data = inner_data.clone();
-                    cloned_data.chapter_groups.iter_mut().for_each(|group| {
-                        group
-                            .first_chapters
-                            .iter_mut()
-                            .for_each(|ch| ch.set_position(proto::ChapterPosition::First));
+                    cloned_data
+                        .chapter_groups_mut()
+                        .iter_mut()
+                        .for_each(|group| {
+                            group
+                                .first_chapters_mut()
+                                .iter_mut()
+                                .for_each(|ch| ch.set_position(proto::ChapterPosition::First));
 
-                        group
-                            .last_chapters
-                            .iter_mut()
-                            .for_each(|ch| ch.set_position(proto::ChapterPosition::Last));
+                            group
+                                .last_chapters_mut()
+                                .iter_mut()
+                                .for_each(|ch| ch.set_position(proto::ChapterPosition::Last));
 
-                        group
-                            .mid_chapters
-                            .iter_mut()
-                            .for_each(|ch| ch.set_position(proto::ChapterPosition::Middle));
-                    });
+                            group
+                                .mid_chapters_mut()
+                                .iter_mut()
+                                .for_each(|ch| ch.set_position(proto::ChapterPosition::Middle));
+                        });
 
                     Ok(APIResponse::Success(Box::new(cloned_data)))
                 }
@@ -444,13 +447,16 @@ impl MPClient {
         split: bool,
     ) -> ToshoResult<APIResponse<proto::ChapterViewer>> {
         let mut query_params = vec![];
-        query_params.push(("chapter_id".to_string(), chapter.chapter_id.to_string()));
+        query_params.push(("chapter_id".to_string(), chapter.chapter_id().to_string()));
         query_params.push((
             "split".to_string(),
             if split { "yes" } else { "no" }.to_string(),
         ));
         query_params.push(("img_quality".to_string(), quality.to_string()));
-        query_params.push(("viewer_mode".to_string(), chapter.default_view_mode()));
+        query_params.push((
+            "viewer_mode".to_string(),
+            chapter.default_view_mode().to_string(),
+        ));
         // Determine the way to read the chapter
         if chapter.is_free() {
             query_params.push(("free_reading".to_string(), "yes".to_string()));
@@ -461,8 +467,8 @@ impl MPClient {
             query_params.push(("free_reading".to_string(), "no".to_string()));
             query_params.push(("subscription_reading".to_string(), "no".to_string()));
         } else {
-            let user_sub = title.user_subscription.clone().unwrap_or_default();
-            let title_labels = title.title_labels.clone().unwrap_or_default();
+            let user_sub = title.user_subscription().cloned().unwrap_or_default();
+            let title_labels = title.title_labels().cloned().unwrap_or_default();
             if user_sub.plan() >= title_labels.plan_type() {
                 query_params.push(("subscription_reading".to_string(), "yes".to_string()));
                 query_params.push(("ticket_reading".to_string(), "no".to_string()));

--- a/tosho_mplus/src/proto/accounts.rs
+++ b/tosho_mplus/src/proto/accounts.rs
@@ -6,44 +6,47 @@
 
 use std::str::FromStr;
 
+use tosho_macros::AutoGetter;
+
 use crate::helper::SubscriptionPlan;
 
 use super::{AvailableLanguages, CommentIcon};
 
 /// Registration data response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct RegistrationData {
     /// Device secret
     #[prost(string, tag = "1")]
-    pub secret: ::prost::alloc::string::String,
+    secret: ::prost::alloc::string::String,
 }
 
 /// User account ticket information
-#[derive(Clone, PartialEq, Copy, ::prost::Message)]
+#[derive(Clone, Copy, AutoGetter, PartialEq, ::prost::Message)]
 pub struct UserTickets {
     /// Current ticket amount
     #[prost(uint64, tag = "1")]
-    pub ticket: u64,
+    ticket: u64,
     /// Next ticket refresh in UNIX timestamp
     #[prost(int64, tag = "2")]
-    pub next_refresh: i64,
+    next_refresh: i64,
 }
 
 /// User account subscription information
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct UserSubscription {
     /// Subscription plan type
     #[prost(string, tag = "1")]
-    pub plan: ::prost::alloc::string::String,
+    #[skip_field]
+    plan: ::prost::alloc::string::String,
     /// Next payment in UNIX timestamp
     #[prost(uint64, tag = "2")]
-    pub next_payment: u64,
+    next_payment: u64,
     /// Is the current subscription a trial?
     #[prost(bool, tag = "3")]
-    pub trial: bool,
+    trial: bool,
     /// Is the subscription is currently on the process being downgraded?
     #[prost(bool, tag = "4")]
-    pub downgrading: bool,
+    downgrading: bool,
 }
 
 impl UserSubscription {
@@ -64,23 +67,23 @@ impl UserSubscription {
 /// This is a `v1` implementation of the user settings response.
 ///
 /// See also: [`UserSettingsV2`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct UserSettings {
     /// User icon info
     #[prost(message, optional, tag = "1")]
-    pub icon: ::core::option::Option<CommentIcon>,
+    icon: ::core::option::Option<CommentIcon>,
     /// User display name
     #[prost(string, tag = "2")]
-    pub user_name: ::prost::alloc::string::String,
+    user_name: ::prost::alloc::string::String,
     /// User wants notification for news and events
     #[prost(bool, tag = "3")]
-    pub news_notification: bool,
+    news_notification: bool,
     /// User wants notification for chapter updates
     #[prost(bool, tag = "4")]
-    pub chapter_notification: bool,
+    chapter_notification: bool,
     /// English title count
     #[prost(uint64, tag = "5")]
-    pub english_title_count: u64,
+    english_title_count: u64,
 }
 
 /// User settings response
@@ -88,57 +91,59 @@ pub struct UserSettings {
 /// This is a `v2` implementation of the user settings response.
 ///
 /// See also: [`UserSettings`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct UserSettingsV2 {
     /// User icon info
     #[prost(message, optional, tag = "1")]
-    pub icon: ::core::option::Option<CommentIcon>,
+    icon: ::core::option::Option<CommentIcon>,
     /// User display name
     #[prost(string, tag = "2")]
-    pub user_name: ::prost::alloc::string::String,
+    user_name: ::prost::alloc::string::String,
     /// User wants notification for news and events
     #[prost(bool, tag = "3")]
-    pub news_notification: bool,
+    news_notification: bool,
     /// User wants notification for chapter updates
     #[prost(bool, tag = "4")]
-    pub chapter_notification: bool,
+    chapter_notification: bool,
     /// Available languages with title count
     #[prost(message, repeated, tag = "5")]
-    pub languages: ::prost::alloc::vec::Vec<AvailableLanguages>,
+    languages: ::prost::alloc::vec::Vec<AvailableLanguages>,
     /// User subscription information
     #[prost(message, optional, tag = "6")]
-    pub subscription: ::core::option::Option<UserSubscription>,
+    subscription: ::core::option::Option<UserSubscription>,
 }
 
 /// User profile settings response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct UserProfileSettings {
     /// A list of available icons
     #[prost(message, repeated, tag = "1")]
-    pub icons: ::prost::alloc::vec::Vec<CommentIcon>,
+    icons: ::prost::alloc::vec::Vec<CommentIcon>,
     /// User display name
     #[prost(string, optional, tag = "2")]
-    pub user_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    user_name: ::core::option::Option<::prost::alloc::string::String>,
     /// User icon info
     #[prost(message, optional, tag = "3")]
-    pub icon: ::core::option::Option<CommentIcon>,
+    icon: ::core::option::Option<CommentIcon>,
 }
 
 /// User profile update result response
-#[derive(Clone, PartialEq, Copy, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct UserUpdateProfileResult {
     /// Result of the profile update
     #[prost(enumeration = "super::UpdateProfileResult", tag = "1")]
-    pub result: i32,
+    result: i32,
 }
 
 /// Push token response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct PushTokenResponse {
     /// The received token
     #[prost(string, tag = "1")]
-    pub token: ::prost::alloc::string::String,
+    token: ::prost::alloc::string::String,
     /// The token timestamp
     #[prost(int64, optional, tag = "2")]
-    pub timestamp: ::core::option::Option<i64>,
+    #[skip_field]
+    timestamp: ::core::option::Option<i64>,
 }

--- a/tosho_mplus/src/proto/chapters.rs
+++ b/tosho_mplus/src/proto/chapters.rs
@@ -4,60 +4,66 @@
 
 use std::str::FromStr;
 
+use tosho_macros::AutoGetter;
+
 use crate::helper::SubscriptionPlan;
 
 use super::ChapterPosition;
 
 /// A single chapter information
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct Chapter {
     /// Title ID
     #[prost(uint64, tag = "1")]
-    pub title_id: u64,
+    title_id: u64,
     /// Chapter ID
     #[prost(uint64, tag = "2")]
-    pub chapter_id: u64,
+    chapter_id: u64,
     /// Chapter title
     #[prost(string, tag = "3")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
     /// Chapter subtitle
     #[prost(string, optional, tag = "4")]
-    pub subtitle: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    subtitle: ::core::option::Option<::prost::alloc::string::String>,
     /// Chapter thumbnail URL
     #[prost(string, tag = "5")]
-    pub thumbnail: ::prost::alloc::string::String,
+    thumbnail: ::prost::alloc::string::String,
     /// Chapter published/start UNIX timestamp
     #[prost(int64, tag = "6")]
-    pub published_at: i64,
+    published_at: i64,
     /// Chapter end viewing period UNIX timestamp
     #[prost(int64, optional, tag = "7")]
-    pub end_at: ::core::option::Option<i64>,
+    #[skip_field]
+    end_at: ::core::option::Option<i64>,
     /// Is the chapter already viewed?
     #[prost(bool, tag = "8")]
-    pub viewed: bool,
+    viewed: bool,
     /// Is the chapter can be read in vertical mode only?
     #[prost(bool, tag = "9")]
-    pub vertical_only: bool,
+    vertical_only: bool,
     /// Chapter end viewing by ticket timestamp
     #[prost(int64, optional, tag = "10")]
-    pub ticket_end_at: ::core::option::Option<i64>,
+    #[skip_field]
+    ticket_end_at: ::core::option::Option<i64>,
     /// Is the chapter can be read for free?
     #[prost(bool, tag = "11")]
-    pub free: bool,
+    free: bool,
     /// Is the chapter can be read in horizontal mode only?
     #[prost(bool, tag = "12")]
-    pub horizontal_only: bool,
+    horizontal_only: bool,
     /// Chapter view count
     #[prost(uint64, tag = "13")]
-    pub view_count: u64,
+    view_count: u64,
     /// Chapter comment count
     #[prost(uint64, tag = "14")]
-    pub comment_count: u64,
+    comment_count: u64,
     /// Chapter position in the group
     ///
     /// This is assigned client side.
     #[prost(enumeration = "super::ChapterPosition", tag = "999")]
-    pub position: i32,
+    #[skip_field]
+    position: i32,
 }
 
 impl Chapter {
@@ -94,11 +100,11 @@ impl Chapter {
     }
 
     /// Get the default viewing mode
-    pub fn default_view_mode(&self) -> String {
+    pub fn default_view_mode(&self) -> &'static str {
         if self.vertical_only {
-            "vertical".to_string()
+            "vertical"
         } else {
-            "horizontal".to_string()
+            "horizontal"
         }
     }
 
@@ -116,20 +122,20 @@ impl Chapter {
 }
 
 /// A group of chapters
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct ChapterGroup {
     /// The chapter numbers range
     #[prost(string, tag = "1")]
-    pub chapters: ::prost::alloc::string::String,
+    chapters: ::prost::alloc::string::String,
     /// The first chapters list, all of them should be free to read
     #[prost(message, repeated, tag = "2")]
-    pub first_chapters: ::prost::alloc::vec::Vec<Chapter>,
+    first_chapters: ::prost::alloc::vec::Vec<Chapter>,
     /// The mid chapters list, this chapter is locked behind subscriptions or tickets
     #[prost(message, repeated, tag = "3")]
-    pub mid_chapters: ::prost::alloc::vec::Vec<Chapter>,
+    mid_chapters: ::prost::alloc::vec::Vec<Chapter>,
     /// The last chapters list, all of them should be free to read
     #[prost(message, repeated, tag = "4")]
-    pub last_chapters: ::prost::alloc::vec::Vec<Chapter>,
+    last_chapters: ::prost::alloc::vec::Vec<Chapter>,
 }
 
 impl ChapterGroup {
@@ -141,45 +147,50 @@ impl ChapterGroup {
         chapters.extend_from_slice(&self.last_chapters);
         chapters
     }
+
+    /// Get the mutable reference to first chapters
+    pub fn first_chapters_mut(&mut self) -> &mut Vec<Chapter> {
+        &mut self.first_chapters
+    }
+
+    /// Get the mutable reference to mid chapters
+    pub fn mid_chapters_mut(&mut self) -> &mut Vec<Chapter> {
+        &mut self.mid_chapters
+    }
+
+    /// Get the mutable reference to last chapters
+    pub fn last_chapters_mut(&mut self) -> &mut Vec<Chapter> {
+        &mut self.last_chapters
+    }
 }
 
 /// A page of a chapter
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct ChapterPage {
     /// The page url
     #[prost(string, tag = "1")]
-    pub url: ::prost::alloc::string::String,
+    url: ::prost::alloc::string::String,
     /// The image width
     #[prost(uint64, tag = "2")]
-    pub width: u64,
+    width: u64,
     /// The image height
     #[prost(uint64, tag = "3")]
-    pub height: u64,
+    height: u64,
     /// The image type/kind
     #[prost(enumeration = "super::PageType", tag = "4")]
-    pub kind: i32,
+    #[skip_field]
+    kind: i32,
     /// The image encryption key
     #[prost(string, optional, tag = "5")]
-    pub key: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    key: ::core::option::Option<::prost::alloc::string::String>,
 }
 
 impl ChapterPage {
     /// The file name of the image.
     ///
-    /// # Examples
-    /// ```rust
-    /// use tosho_mplus::proto::ChapterPage;
-    ///
-    /// let page = ChapterPage {
-    ///     url: "https://example.com/path/to/image/9643032.webp?query=param".to_string(),
-    ///     width: 784,
-    ///     height: 1145,
-    ///     kind: 0,
-    ///     key: None,
-    /// };
-    ///
-    /// assert_eq!(page.file_name(), "9643032.webp");
-    /// ```
+    /// When you have the URL of `https://example.com/image.webp?ignore=me`,
+    /// the filename would become `image.webp` including the extension.
     pub fn file_name(&self) -> String {
         let url = self.url.clone();
         // split at the last slash
@@ -191,20 +202,9 @@ impl ChapterPage {
 
     /// The file extension of the image.
     ///
-    /// # Examples
-    /// ```rust
-    /// use tosho_mplus::proto::ChapterPage;
-    ///
-    /// let page = ChapterPage {
-    ///     url: "https://example.com/path/to/image/9643032.webp?query=param".to_string(),
-    ///     width: 784,
-    ///     height: 1145,
-    ///     kind: 0,
-    ///     key: None,
-    /// };
-    ///
-    /// assert_eq!(page.extension(), "webp");
-    /// ```
+    /// When you have the URL of `https://example.com/image.webp?ignore=me`,
+    /// the extension would become `webp`, when there is no extension it
+    /// would return an empty string.
     pub fn extension(&self) -> String {
         let file_name = self.file_name();
         // split at the last dot
@@ -219,20 +219,8 @@ impl ChapterPage {
 
     /// The file stem of the image.
     ///
-    /// # Examples
-    /// ```rust
-    /// use tosho_mplus::proto::ChapterPage;
-    ///
-    /// let page = ChapterPage {
-    ///     url: "https://example.com/path/to/image/9643032.webp?query=param".to_string(),
-    ///     width: 784,
-    ///     height: 1145,
-    ///     kind: 0,
-    ///     key: None,
-    /// };
-    ///
-    /// assert_eq!(page.file_stem(), "9643032");
-    /// ```
+    /// When you have the URL of `https://example.com/image.webp?ignore=me`,
+    /// the file stem would become `image`.
     pub fn file_stem(&self) -> String {
         let file_name = self.file_name();
         // split at the last dot
@@ -247,123 +235,128 @@ impl ChapterPage {
 }
 
 /// A chapter page of a banners
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct ChapterPageBanner {
     /// Banner title
     #[prost(string, optional, tag = "1")]
-    pub title: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    title: ::core::option::Option<::prost::alloc::string::String>,
     /// Banner list
     #[prost(message, repeated, tag = "2")]
-    pub banners: ::prost::alloc::vec::Vec<super::common::Banner>,
+    banners: ::prost::alloc::vec::Vec<super::common::Banner>,
 }
 
 /// A chapter last page response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct ChapterPageLastPage {
     /// Current chapter
     #[prost(message, optional, tag = "1")]
-    pub chapter: ::core::option::Option<Chapter>,
+    chapter: ::core::option::Option<Chapter>,
     /// Next chapter
     #[prost(message, optional, tag = "2")]
-    pub next_chapter: ::core::option::Option<Chapter>,
+    next_chapter: ::core::option::Option<Chapter>,
     /// Top comments of this chapter
     #[prost(message, repeated, tag = "3")]
-    pub top_comments: ::prost::alloc::vec::Vec<super::comments::Comment>,
+    top_comments: ::prost::alloc::vec::Vec<super::comments::Comment>,
     /// Is the user subscribed
     #[prost(bool, tag = "4")]
-    pub subscribed: bool,
+    subscribed: bool,
     /// The next chapter timestamp
     #[prost(int64, optional, tag = "5")]
-    pub next_chapter_at: ::core::option::Option<i64>,
+    #[skip_field]
+    next_chapter_at: ::core::option::Option<i64>,
     /// The chapter type
     #[prost(enumeration = "super::ChapterType", tag = "6")]
-    pub chapter_type: i32,
+    #[skip_field]
+    chapter_type: i32,
     /// Movie reward of the chapter
     // #[prost(message, optional, tag = "8")]
-    // pub movie_reward: ::core::option::Option<super::common::PopupMessage>,
+    // movie_reward: ::core::option::Option<super::common::PopupMessage>,
     /// Banner list
     #[prost(message, optional, tag = "9")]
-    pub banner: ::core::option::Option<super::common::Banner>,
+    banner: ::core::option::Option<super::common::Banner>,
     /// Title ticket list
     #[prost(message, repeated, tag = "10")]
-    pub title_tickets: ::prost::alloc::vec::Vec<super::titles::Title>,
+    title_tickets: ::prost::alloc::vec::Vec<super::titles::Title>,
     /// Publisher banner
     #[prost(message, optional, tag = "11")]
-    pub publisher_banner: ::core::option::Option<super::common::Banner>,
+    publisher_banner: ::core::option::Option<super::common::Banner>,
     /// User tickets
     #[prost(message, optional, tag = "12")]
-    pub user_tickets: ::core::option::Option<super::accounts::UserTickets>,
+    #[copyable]
+    user_tickets: ::core::option::Option<super::accounts::UserTickets>,
     /// Is next chapter can be read by ticket?
     #[prost(bool, tag = "13")]
-    pub next_chapter_ticket: bool,
+    next_chapter_ticket: bool,
     /// Is next chapter can be read for free one time only?
     #[prost(bool, tag = "14")]
-    pub next_chapter_free: bool,
+    next_chapter_free: bool,
     /// Is next chapter can be read only with subscription?
     #[prost(bool, tag = "16")]
-    pub next_chapter_subscription: bool,
+    next_chapter_subscription: bool,
 }
 
 /// A chapter page response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct ChapterPageResponse {
     /// A response to a chapter page (a.k.a the manga page)
     #[prost(message, optional, tag = "1")]
-    pub page: ::core::option::Option<ChapterPage>,
+    page: ::core::option::Option<ChapterPage>,
     /// A response to a banner page
     #[prost(message, optional, tag = "2")]
-    pub banner: ::core::option::Option<ChapterPageBanner>,
+    banner: ::core::option::Option<ChapterPageBanner>,
     /// A response to a last page
     #[prost(message, optional, tag = "3")]
-    pub last_page: ::core::option::Option<ChapterPageLastPage>,
+    last_page: ::core::option::Option<ChapterPageLastPage>,
     /// A response to an insert banner
     #[prost(message, optional, tag = "5")]
-    pub insert_banner: ::core::option::Option<ChapterPageBanner>,
+    insert_banner: ::core::option::Option<ChapterPageBanner>,
 }
 
 /// A chapter viewer response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct ChapterViewer {
     /// Chapter pages
     #[prost(message, repeated, tag = "1")]
-    pub pages: ::prost::alloc::vec::Vec<ChapterPageResponse>,
+    pages: ::prost::alloc::vec::Vec<ChapterPageResponse>,
     /// Chapter ID
     #[prost(uint64, tag = "2")]
-    pub chapter_id: u64,
+    chapter_id: u64,
     /// All available chapters
     #[prost(message, repeated, tag = "3")]
-    pub chapters: ::prost::alloc::vec::Vec<Chapter>,
+    chapters: ::prost::alloc::vec::Vec<Chapter>,
     // SNS: 4
     /// Manga title
     #[prost(string, tag = "5")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
     /// Chapter title
     #[prost(string, tag = "6")]
-    pub chapter_title: ::prost::alloc::string::String,
+    chapter_title: ::prost::alloc::string::String,
     /// Number of comments
     #[prost(uint64, tag = "7")]
-    pub comment_count: u64,
+    comment_count: u64,
     /// Is vertical only?
     #[prost(bool, tag = "8")]
-    pub vertical_only: bool,
+    vertical_only: bool,
     /// Title ID
     #[prost(uint64, tag = "9")]
-    pub title_id: u64,
+    title_id: u64,
     /// Is the first page on the right side (first page is odd number)
     #[prost(bool, tag = "10")]
-    pub first_page_right: bool,
+    first_page_right: bool,
     /// Region code of the title
     #[prost(string, tag = "11")]
-    pub region_code: ::prost::alloc::string::String,
+    region_code: ::prost::alloc::string::String,
     /// Is horizontal only?
     #[prost(bool, tag = "12")]
-    pub horizontal_only: bool,
+    horizontal_only: bool,
     /// User subscription info
     #[prost(message, optional, tag = "13")]
-    pub user_subscription: ::core::option::Option<super::accounts::UserSubscription>,
+    user_subscription: ::core::option::Option<super::accounts::UserSubscription>,
     /// User plan type
     #[prost(string, tag = "14")]
-    pub plan_type: ::prost::alloc::string::String,
+    #[skip_field]
+    plan_type: ::prost::alloc::string::String,
 }
 
 impl ChapterViewer {

--- a/tosho_mplus/src/proto/chapters.rs
+++ b/tosho_mplus/src/proto/chapters.rs
@@ -167,7 +167,7 @@ impl ChapterPage {
     /// The file name of the image.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_mplus::proto::ChapterPage;
     ///
     /// let page = ChapterPage {
@@ -192,7 +192,7 @@ impl ChapterPage {
     /// The file extension of the image.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_mplus::proto::ChapterPage;
     ///
     /// let page = ChapterPage {
@@ -220,7 +220,7 @@ impl ChapterPage {
     /// The file stem of the image.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_mplus::proto::ChapterPage;
     ///
     /// let page = ChapterPage {

--- a/tosho_mplus/src/proto/comments.rs
+++ b/tosho_mplus/src/proto/comments.rs
@@ -4,56 +4,58 @@
 
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+use tosho_macros::AutoGetter;
+
 /// A comment response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct Comment {
     /// The comment ID
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// The comment index
     #[prost(uint64, tag = "2")]
-    pub index: u64,
+    index: u64,
     /// The commentor user name
     #[prost(string, tag = "3")]
-    pub user_name: ::prost::alloc::string::String,
+    user_name: ::prost::alloc::string::String,
     /// The commentor user avatar URL
     #[prost(string, tag = "4")]
-    pub user_avatar: ::prost::alloc::string::String,
+    user_avatar: ::prost::alloc::string::String,
     /// Is the commentor ourselves?
     #[prost(bool, tag = "6")]
-    pub is_self: bool,
+    is_self: bool,
     /// Is the comment liked by us?
     #[prost(bool, tag = "7")]
-    pub liked: bool,
+    liked: bool,
     /// The number of likes
     #[prost(uint64, tag = "9")]
-    pub likes: u64,
+    likes: u64,
     /// The comment content/body
     #[prost(string, tag = "10")]
-    pub content: ::prost::alloc::string::String,
+    content: ::prost::alloc::string::String,
     /// The UNIX timestamp of the comment creation
     #[prost(int64, tag = "11")]
-    pub timestamp: i64,
+    timestamp: i64,
 }
 
 /// A comment icon data
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct CommentIcon {
     /// The comment icon ID
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// The comment icon URL
     #[prost(string, tag = "2")]
-    pub url: ::prost::alloc::string::String,
+    url: ::prost::alloc::string::String,
 }
 
 /// A comment list response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct CommentList {
     /// The list of comments
     #[prost(message, repeated, tag = "1")]
-    pub comments: ::prost::alloc::vec::Vec<Comment>,
+    comments: ::prost::alloc::vec::Vec<Comment>,
     #[prost(bool, tag = "2")]
-    #[allow(missing_docs)]
-    pub set_user_name: bool,
+    #[allow(clippy::missing_docs_in_private_items)]
+    set_user_name: bool,
 }

--- a/tosho_mplus/src/proto/comments.rs
+++ b/tosho_mplus/src/proto/comments.rs
@@ -54,5 +54,6 @@ pub struct CommentList {
     #[prost(message, repeated, tag = "1")]
     pub comments: ::prost::alloc::vec::Vec<Comment>,
     #[prost(bool, tag = "2")]
+    #[allow(missing_docs)]
     pub set_user_name: bool,
 }

--- a/tosho_mplus/src/proto/common.rs
+++ b/tosho_mplus/src/proto/common.rs
@@ -6,6 +6,8 @@
 
 use std::str::FromStr;
 
+use tosho_macros::AutoGetter;
+
 use crate::helper::SubscriptionPlan;
 
 use super::enums::{ErrorAction, Language};
@@ -15,32 +17,35 @@ use super::enums::{ErrorAction, Language};
 pub struct PopupButton {
     /// The button action.
     #[prost(string, optional, tag = "1")]
-    pub text: ::core::option::Option<::prost::alloc::string::String>,
+    text: ::core::option::Option<::prost::alloc::string::String>,
     // There is also a `action` but it's tied to system.
     // So we don't need to implement it.
 }
 
 /// A default Popup response.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct PopupMessage {
     /// The message subject.
     #[prost(string, optional, tag = "1")]
-    pub subject: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    subject: ::core::option::Option<::prost::alloc::string::String>,
     /// The message body.
     #[prost(string, optional, tag = "2")]
-    pub body: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    body: ::core::option::Option<::prost::alloc::string::String>,
     /// The OK button action.
     #[prost(message, optional, tag = "3")]
-    pub ok_button: ::core::option::Option<PopupButton>,
+    ok_button: ::core::option::Option<PopupButton>,
     /// The neutral button action.
     #[prost(message, optional, tag = "4")]
-    pub neutral_button: ::core::option::Option<PopupButton>,
+    neutral_button: ::core::option::Option<PopupButton>,
     /// The cancel button action.
     #[prost(message, optional, tag = "5")]
-    pub cancel_button: ::core::option::Option<PopupButton>,
+    cancel_button: ::core::option::Option<PopupButton>,
     /// The language of the message.
     #[prost(enumeration = "Language", tag = "6")]
-    pub language: i32,
+    #[skip_field]
+    language: i32,
 }
 
 impl PopupMessage {
@@ -59,23 +64,25 @@ impl PopupMessage {
 }
 
 /// An error response.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct ErrorResponse {
     /// The error action or error code of the request.
     #[prost(enumeration = "ErrorAction", tag = "1")]
-    pub action: i32,
+    #[skip_field]
+    action: i32,
     /// English popup message
     #[prost(message, optional, tag = "2")]
-    pub english_popup: ::core::option::Option<PopupMessage>,
+    english_popup: ::core::option::Option<PopupMessage>,
     /// Spanish popup message
     #[prost(message, optional, tag = "3")]
-    pub spanish_popup: ::core::option::Option<PopupMessage>,
+    spanish_popup: ::core::option::Option<PopupMessage>,
     /// Debug message
     #[prost(string, optional, tag = "4")]
-    pub debug_message: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    debug_message: ::core::option::Option<::prost::alloc::string::String>,
     /// Array of other popup messages
     #[prost(message, repeated, tag = "5")]
-    pub other_popups: ::prost::alloc::vec::Vec<PopupMessage>,
+    other_popups: ::prost::alloc::vec::Vec<PopupMessage>,
 }
 
 impl ErrorResponse {
@@ -131,111 +138,119 @@ impl ErrorResponse {
 }
 
 /// The banner data.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct Banner {
     /// The banner image.
     #[prost(string, tag = "1")]
-    pub image: ::prost::alloc::string::String,
+    image: ::prost::alloc::string::String,
     /// The associated ID.
     #[prost(uint64, optional, tag = "3")]
-    pub id: Option<u64>,
+    #[skip_field]
+    id: Option<u64>,
     /// The banner width.
     #[prost(uint32, optional, tag = "4")]
-    pub width: Option<u32>,
+    #[skip_field]
+    width: Option<u32>,
     /// The banner height.
     #[prost(uint32, optional, tag = "5")]
-    pub height: Option<u32>,
+    #[skip_field]
+    height: Option<u32>,
 }
 
 /// A tag information
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct Tag {
     /// Tag ID
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// Tag slug
     #[prost(string, tag = "2")]
-    pub slug: ::prost::alloc::string::String,
+    slug: ::prost::alloc::string::String,
 }
 
 /// A label information
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct Label {
     /// Label ID
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// Label description
     #[prost(string, tag = "2")]
-    pub description: ::prost::alloc::string::String,
+    description: ::prost::alloc::string::String,
 }
 
 /// A publisher news information
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct PublisherNews {
     /// Publisher news ID
     #[prost(uint64, tag = "1")]
-    pub news_id: u64,
+    news_id: u64,
     /// Publisher ID
     #[prost(uint64, tag = "2")]
-    pub publisher_id: u64,
+    publisher_id: u64,
     /// Publisher name
     #[prost(string, tag = "3")]
-    pub name: ::prost::alloc::string::String,
+    name: ::prost::alloc::string::String,
     /// Publisher news title
     #[prost(string, tag = "4")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
     /// Publisher news content
     #[prost(string, tag = "5")]
-    pub content: ::prost::alloc::string::String,
+    content: ::prost::alloc::string::String,
     /// Time of publication in UNIX timestamp
     #[prost(uint64, tag = "6")]
-    pub published_at: u64,
+    published_at: u64,
 }
 
 /// A publisher information
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct PublisherItem {
     /// The publisher banner info
     #[prost(message, optional, tag = "1")]
-    pub banner: ::core::option::Option<Banner>,
+    banner: ::core::option::Option<Banner>,
     /// The publisher news
     #[prost(message, optional, tag = "2")]
-    pub news: ::core::option::Option<PublisherNews>,
+    news: ::core::option::Option<PublisherNews>,
 }
 
 /// Available languages in the source.
-#[derive(Clone, PartialEq, Copy, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, Copy, ::prost::Message)]
 pub struct AvailableLanguages {
     /// The language
     #[prost(enumeration = "Language", tag = "1")]
-    pub language: i32,
+    #[skip_field]
+    language: i32,
     /// Total count of titles available in the language
     #[prost(uint64, tag = "2")]
-    pub titles_count: u64,
+    titles_count: u64,
 }
 
 /// A information about the current languages
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct Languages {
     /// The current UI language
     #[prost(enumeration = "Language", tag = "1")]
-    pub language: i32,
+    #[skip_field]
+    language: i32,
     /// The content language
     #[prost(enumeration = "Language", optional, tag = "2")]
-    pub content_language: ::core::option::Option<i32>,
+    #[skip_field]
+    content_language: ::core::option::Option<i32>,
     /// The secondary content language
     ///
     /// This will take priority over the first content language.
     #[prost(enumeration = "Language", optional, tag = "3")]
-    pub content_language_secondary: ::core::option::Option<i32>,
+    #[skip_field]
+    content_language_secondary: ::core::option::Option<i32>,
     /// The tertiary content language
     ///
     /// This will take priority over the first and second content language.
     #[prost(enumeration = "Language", optional, tag = "4")]
-    pub content_language_tertiary: ::core::option::Option<i32>,
+    #[skip_field]
+    content_language_tertiary: ::core::option::Option<i32>,
     /// The available languages
     #[prost(message, repeated, tag = "5")]
-    pub availables: ::prost::alloc::vec::Vec<AvailableLanguages>,
+    availables: ::prost::alloc::vec::Vec<AvailableLanguages>,
 }
 
 impl Languages {
@@ -255,54 +270,56 @@ impl Languages {
 }
 
 /// A subscription offer for Android device
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct SubscriptionOfferAndroid {
     /// The offer tag
     #[prost(string, tag = "1")]
-    pub tag: ::prost::alloc::string::String,
+    tag: ::prost::alloc::string::String,
 }
 
 /// A subscription offer for Apple device
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct SubscriptionOfferApple {
     /// The offer type
     #[prost(enumeration = "super::PlanOfferType", tag = "1")]
-    pub kind: i32,
+    #[skip_field]
+    kind: i32,
     /// The signature info
     #[prost(string, tag = "2")]
-    pub signature: ::prost::alloc::string::String,
+    signature: ::prost::alloc::string::String,
     /// The apple key info
     #[prost(string, tag = "3")]
-    pub key: ::prost::alloc::string::String,
+    key: ::prost::alloc::string::String,
     /// The nonce info
     #[prost(string, tag = "4")]
-    pub nonce: ::prost::alloc::string::String,
+    nonce: ::prost::alloc::string::String,
     /// The timestamp info
     #[prost(string, tag = "5")]
-    pub timestamp: ::prost::alloc::string::String,
+    timestamp: ::prost::alloc::string::String,
     /// The identifier info
     #[prost(string, tag = "6")]
-    pub identifier: ::prost::alloc::string::String,
+    identifier: ::prost::alloc::string::String,
 }
 
 /// A plan information
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct Plan {
     /// The plan name/ID
     #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
+    #[skip_field]
+    name: ::prost::alloc::string::String,
     /// The plan description
     #[prost(string, tag = "2")]
-    pub description: ::prost::alloc::string::String,
+    description: ::prost::alloc::string::String,
     /// The plan product ID
     #[prost(string, tag = "3")]
-    pub product_id: ::prost::alloc::string::String,
+    product_id: ::prost::alloc::string::String,
     /// The subscription offer for apple devices
     #[prost(message, optional, tag = "4")]
-    pub apple_offer: ::core::option::Option<SubscriptionOfferApple>,
+    apple_offer: ::core::option::Option<SubscriptionOfferApple>,
     /// The subscription offer for android devices
     #[prost(message, repeated, tag = "5")]
-    pub android_offer: ::prost::alloc::vec::Vec<SubscriptionOfferAndroid>,
+    android_offer: ::prost::alloc::vec::Vec<SubscriptionOfferAndroid>,
 }
 
 impl Plan {

--- a/tosho_mplus/src/proto/enums.rs
+++ b/tosho_mplus/src/proto/enums.rs
@@ -54,7 +54,7 @@ impl Language {
     /// Get the pretty name of the language.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_mplus::proto::Language;
     ///
     /// let pt_br = Language::BrazilianPortuguese;
@@ -68,7 +68,7 @@ impl Language {
     /// Get the language code for the language.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_mplus::proto::Language;
     ///
     /// let english = Language::English;
@@ -93,7 +93,7 @@ impl Language {
     /// Get the country code for the language.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_mplus::proto::Language;
     ///
     /// let english = Language::English;
@@ -229,7 +229,7 @@ impl TitleReleaseSchedule {
     /// Get the pretty name of the release schedule.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_mplus::proto::TitleReleaseSchedule;
     ///
     /// let biweekly = TitleReleaseSchedule::BiWeekly;

--- a/tosho_mplus/src/proto/home_view.rs
+++ b/tosho_mplus/src/proto/home_view.rs
@@ -4,6 +4,8 @@
 
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+use tosho_macros::AutoGetter;
+
 use super::{Banner, PopupMessage};
 
 /// Home view response
@@ -13,20 +15,20 @@ use super::{Banner, PopupMessage};
 /// See also: [`HomeViewV2`] and [`HomeViewV3`]
 ///
 /// And the web version: [`WebHomeView`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct HomeView {
     /// The collection of top banner in the home page.
     #[prost(message, repeated, tag = "1")]
-    pub top_banners: ::prost::alloc::vec::Vec<Banner>,
+    top_banners: ::prost::alloc::vec::Vec<Banner>,
     /// The list of featured/updated titles.
     #[prost(message, repeated, tag = "2")]
-    pub titles: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroup>,
+    titles: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroup>,
     /// Popup banner information.
     #[prost(message, optional, tag = "9")]
-    pub popup_banner: ::core::option::Option<PopupMessage>,
+    popup_banner: ::core::option::Option<PopupMessage>,
     /// Should the popup banner be shown or not.
     #[prost(bool, tag = "10")]
-    pub show_popup: bool,
+    show_popup: bool,
 }
 
 /// Home view response
@@ -36,29 +38,29 @@ pub struct HomeView {
 /// See also: [`HomeView`] and [`HomeViewV3`]
 ///
 /// And the web version: [`WebHomeViewV2`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct HomeViewV2 {
     /// The collection of top banner in the home page.
     #[prost(message, repeated, tag = "1")]
-    pub top_banners: ::prost::alloc::vec::Vec<Banner>,
+    top_banners: ::prost::alloc::vec::Vec<Banner>,
     /// The updated titles.
     #[prost(message, repeated, tag = "2")]
-    pub updated_titles: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroupOriginal>,
+    updated_titles: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroupOriginal>,
     /// History of recently read titles.
     #[prost(message, repeated, tag = "3")]
-    pub history: ::prost::alloc::vec::Vec<super::titles::SubscribedTitle>,
+    history: ::prost::alloc::vec::Vec<super::titles::SubscribedTitle>,
     /// Upcoming chapter of the titles.
     #[prost(message, repeated, tag = "4")]
-    pub upcoming: ::prost::alloc::vec::Vec<super::titles::UpcomingChapterTitle>,
+    upcoming: ::prost::alloc::vec::Vec<super::titles::UpcomingChapterTitle>,
     /// A title that is highlighted.
     #[prost(message, optional, tag = "5")]
-    pub highlighted: ::core::option::Option<super::titles::HighlightedTitle>,
+    highlighted: ::core::option::Option<super::titles::HighlightedTitle>,
     /// Popup banner information.
     #[prost(message, optional, tag = "9")]
-    pub popup_banner: ::core::option::Option<PopupMessage>,
+    popup_banner: ::core::option::Option<PopupMessage>,
     /// Should the popup banner be shown or not.
     #[prost(bool, tag = "10")]
-    pub show_popup: bool,
+    show_popup: bool,
 }
 
 /// Home view response
@@ -66,26 +68,26 @@ pub struct HomeViewV2 {
 /// The following is `v3` implementation of the home view response.
 ///
 /// See also: [`HomeView`] and [`HomeViewV2`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct HomeViewV3 {
     /// The collection of top banner in the home page.
     #[prost(message, repeated, tag = "1")]
-    pub top_banners: ::prost::alloc::vec::Vec<Banner>,
+    top_banners: ::prost::alloc::vec::Vec<Banner>,
     /// The updated title groups
     #[prost(message, repeated, tag = "2")]
-    pub groups: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroupV2>,
+    groups: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroupV2>,
     /// Popup banner information.
     #[prost(message, optional, tag = "9")]
-    pub popup_banner: ::core::option::Option<PopupMessage>,
+    popup_banner: ::core::option::Option<PopupMessage>,
     /// Should the popup banner be shown or not.
     #[prost(bool, tag = "10")]
-    pub show_popup: bool,
+    show_popup: bool,
     /// The user subscription information
     #[prost(message, optional, tag = "11")]
-    pub subscription: ::core::option::Option<super::accounts::UserSubscription>,
+    subscription: ::core::option::Option<super::accounts::UserSubscription>,
     /// Service announcements
     #[prost(message, repeated, tag = "12")]
-    pub announcement: ::prost::alloc::vec::Vec<super::others::ServiceAnnouncement>,
+    announcement: ::prost::alloc::vec::Vec<super::others::ServiceAnnouncement>,
 }
 
 /// Web version of home view
@@ -95,26 +97,26 @@ pub struct HomeViewV3 {
 /// See also: [`WebHomeViewV2`], [`WebHomeViewV3`], and [`WebHomeViewV4`]
 ///
 /// And the app version: [`HomeView`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct WebHomeView {
     /// The collection of top banner in the home page.
     #[prost(message, repeated, tag = "1")]
-    pub top_banners: ::prost::alloc::vec::Vec<Banner>,
+    top_banners: ::prost::alloc::vec::Vec<Banner>,
     /// The list of featured/updated titles.
     #[prost(message, repeated, tag = "2")]
-    pub titles: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroup>,
+    titles: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroup>,
     /// The current titles ranking.
     #[prost(message, repeated, tag = "3")]
-    pub rankings: ::prost::alloc::vec::Vec<super::titles::Title>,
+    rankings: ::prost::alloc::vec::Vec<super::titles::Title>,
     /// Popup banner information.
     #[prost(message, optional, tag = "4")]
-    pub popup_banner: ::core::option::Option<PopupMessage>,
+    popup_banner: ::core::option::Option<PopupMessage>,
     /// Featured titles.
     #[prost(message, repeated, tag = "5")]
-    pub featured_titles: ::prost::alloc::vec::Vec<super::titles::TitleList>,
+    featured_titles: ::prost::alloc::vec::Vec<super::titles::TitleList>,
     /// Should the popup banner be shown or not.
     #[prost(bool, tag = "10")]
-    pub show_popup: bool,
+    show_popup: bool,
 }
 
 /// Web version of home view
@@ -124,32 +126,32 @@ pub struct WebHomeView {
 /// See also: [`WebHomeView`], [`WebHomeViewV3`], and [`WebHomeViewV4`]
 ///
 /// And the app version: [`HomeViewV2`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct WebHomeViewV2 {
     /// The collection of top banner in the home page.
     #[prost(message, repeated, tag = "1")]
-    pub top_banners: ::prost::alloc::vec::Vec<Banner>,
+    top_banners: ::prost::alloc::vec::Vec<Banner>,
     /// The updated titles.
     #[prost(message, repeated, tag = "2")]
-    pub updated_titles: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroupOriginal>,
+    updated_titles: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroupOriginal>,
     /// History of recently read titles.
     #[prost(message, repeated, tag = "3")]
-    pub history: ::prost::alloc::vec::Vec<super::titles::SubscribedTitle>,
+    history: ::prost::alloc::vec::Vec<super::titles::SubscribedTitle>,
     /// Upcoming chapter of the titles.
     #[prost(message, repeated, tag = "4")]
-    pub upcoming: ::prost::alloc::vec::Vec<super::titles::UpcomingChapterTitle>,
+    upcoming: ::prost::alloc::vec::Vec<super::titles::UpcomingChapterTitle>,
     /// A title that is highlighted.
     #[prost(message, optional, tag = "5")]
-    pub highlighted: ::core::option::Option<super::titles::HighlightedTitle>,
+    highlighted: ::core::option::Option<super::titles::HighlightedTitle>,
     /// The current titles ranking.
     #[prost(message, repeated, tag = "6")]
-    pub rankings: ::prost::alloc::vec::Vec<super::titles::Title>,
+    rankings: ::prost::alloc::vec::Vec<super::titles::Title>,
     /// Popup banner information.
     #[prost(message, optional, tag = "7")]
-    pub popup_banner: ::core::option::Option<PopupMessage>,
+    popup_banner: ::core::option::Option<PopupMessage>,
     /// Featured titles.
     #[prost(message, repeated, tag = "8")]
-    pub featured_titles: ::prost::alloc::vec::Vec<super::titles::TitleList>,
+    featured_titles: ::prost::alloc::vec::Vec<super::titles::TitleList>,
 }
 
 /// Web version of home view
@@ -159,23 +161,23 @@ pub struct WebHomeViewV2 {
 /// See also: [`WebHomeView`], [`WebHomeViewV2`], and [`WebHomeViewV4`]
 ///
 /// And the app version: [`HomeViewV3`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct WebHomeViewV3 {
     /// The collection of top banner in the home page.
     #[prost(message, repeated, tag = "1")]
-    pub top_banners: ::prost::alloc::vec::Vec<Banner>,
+    top_banners: ::prost::alloc::vec::Vec<Banner>,
     /// The updated title groups
     #[prost(message, repeated, tag = "2")]
-    pub groups: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroupV2>,
+    groups: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroupV2>,
     /// The current titles ranking.
     #[prost(message, repeated, tag = "3")]
-    pub rankings: ::prost::alloc::vec::Vec<super::titles::Title>,
+    rankings: ::prost::alloc::vec::Vec<super::titles::Title>,
     /// Popup banner information.
     #[prost(message, optional, tag = "4")]
-    pub popup_banner: ::core::option::Option<PopupMessage>,
+    popup_banner: ::core::option::Option<PopupMessage>,
     /// Featured titles.
     #[prost(message, repeated, tag = "5")]
-    pub featured_titles: ::prost::alloc::vec::Vec<super::titles::TitleList>,
+    featured_titles: ::prost::alloc::vec::Vec<super::titles::TitleList>,
 }
 
 /// Web version of home view
@@ -185,24 +187,24 @@ pub struct WebHomeViewV3 {
 /// See also: [`WebHomeView`], [`WebHomeViewV2`], and [`WebHomeViewV3`]
 ///
 /// There is no equivalent app version for this.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct WebHomeViewV4 {
     /// The collection of top banner in the home page.
     #[prost(message, repeated, tag = "1")]
-    pub top_banners: ::prost::alloc::vec::Vec<Banner>,
+    top_banners: ::prost::alloc::vec::Vec<Banner>,
     /// The updated title groups
     #[prost(message, repeated, tag = "2")]
-    pub groups: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroupV2>,
+    groups: ::prost::alloc::vec::Vec<super::titles::UpdatedTitleGroupV2>,
     /// The current titles ranking.
     #[prost(message, repeated, tag = "3")]
-    pub rankings: ::prost::alloc::vec::Vec<super::titles::TitleRankingGroup>,
+    rankings: ::prost::alloc::vec::Vec<super::titles::TitleRankingGroup>,
     /// Popup banner information.
     #[prost(message, optional, tag = "4")]
-    pub popup_banner: ::core::option::Option<PopupMessage>,
+    popup_banner: ::core::option::Option<PopupMessage>,
     /// Featured titles.
     #[prost(message, repeated, tag = "5")]
-    pub featured_titles: ::prost::alloc::vec::Vec<super::titles::TitleList>,
+    featured_titles: ::prost::alloc::vec::Vec<super::titles::TitleList>,
     /// Service announcements
     #[prost(message, repeated, tag = "6")]
-    pub announcements: ::prost::alloc::vec::Vec<super::others::ServiceAnnouncement>,
+    announcements: ::prost::alloc::vec::Vec<super::others::ServiceAnnouncement>,
 }

--- a/tosho_mplus/src/proto/mod.rs
+++ b/tosho_mplus/src/proto/mod.rs
@@ -7,6 +7,7 @@
 //! or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
 #![allow(clippy::derive_partial_eq_without_eq)]
+#![warn(clippy::missing_docs_in_private_items)]
 
 pub mod accounts;
 pub mod chapters;
@@ -25,88 +26,147 @@ pub use enums::*;
 pub use home_view::*;
 pub use others::*;
 pub use titles::*;
+use tosho_macros::AutoGetter;
 
 /// Indicate a success response
 ///
 /// Depending on the request type, not all field will be available.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SuccessResponse {
+    /// Is this a featured manga request or this have featured manga list
     #[prost(bool, optional, tag = "1")]
+    // #[auto_getters(skip_field)]
     pub featured: ::core::option::Option<bool>,
+    /// Registration response information
     #[prost(message, optional, tag = "2")]
     pub registration: ::core::option::Option<RegistrationData>,
+    /// The homepage view, v1 implementation
     #[prost(message, optional, tag = "3")]
     pub home_view: ::core::option::Option<HomeView>,
+    /// The list of featured titles
     #[prost(message, optional, tag = "4")]
     pub featured_titles: ::core::option::Option<FeaturedTitles>,
+    /// The list of all titles
     #[prost(message, optional, tag = "5")]
     pub all_titles: ::core::option::Option<TitleListOnly>,
+    /// The list of titles ranked depending on the request
     #[prost(message, optional, tag = "6")]
     pub title_ranking: ::core::option::Option<TitleListOnly>,
+    /// The current user subscribed ro favorited titles
     #[prost(message, optional, tag = "7")]
     pub subscribed_titles: ::core::option::Option<TitleListOnly>,
+    /// Information about a title
     #[prost(message, optional, tag = "8")]
     pub title_detail: ::core::option::Option<TitleDetail>,
+    /// The list of comments on a chapter
     #[prost(message, optional, tag = "9")]
     pub comment_list: ::core::option::Option<CommentList>,
+    /// The chapter viewer information
     #[prost(message, optional, tag = "10")]
     pub chapter_viewer: ::core::option::Option<ChapterViewer>,
+    /// The web version of homepage view, v1 implementation
     #[prost(message, optional, tag = "11")]
     pub web_home_view: ::core::option::Option<WebHomeView>,
+    /// The user settings information
     #[prost(message, optional, tag = "12")]
     pub user_settings: ::core::option::Option<UserSettings>,
+    /// The user profile settings information
     #[prost(message, optional, tag = "13")]
     pub user_profile_settings: ::core::option::Option<UserProfileSettings>,
+    /// The update profile result
     #[prost(message, optional, tag = "14")]
     pub update_profile_result: ::core::option::Option<UserUpdateProfileResult>,
+    /// The current service announcement, usually used for maintenance notice
     #[prost(message, optional, tag = "15")]
     pub service_announcements: ::core::option::Option<ServiceAnnouncements>,
+    /// Initial view response, used when booting up the app
     #[prost(message, optional, tag = "16")]
     pub initial_view: ::core::option::Option<InitialView>,
+    /// The feedback response
     #[prost(message, optional, tag = "17")]
     pub feedback_view: ::core::option::Option<FeedbackList>,
+    /// The publisher news list
     #[prost(message, optional, tag = "18")]
     pub publisher_news_list: ::core::option::Option<PublisherNewsList>,
+    /// Questionnaire response
     #[prost(message, optional, tag = "19")]
     pub questionnaire: ::core::option::Option<QuestionnaireResponse>,
+    /// The current title updates
     #[prost(message, optional, tag = "20")]
     pub title_updates: ::core::option::Option<TitleUpdates>,
+    /// The homepage view, v2 implementation
     #[prost(message, optional, tag = "21")]
     pub home_view_v2: ::core::option::Option<HomeViewV2>,
+    /// The updated titles list
     #[prost(message, optional, tag = "22")]
     pub updated_titles: ::core::option::Option<UpdatedTitleList>,
+    /// Title that can be read with tickets
     #[prost(message, optional, tag = "23")]
     pub title_tickets: ::core::option::Option<TitleTicketList>,
+    /// The homepage view, v3 implementation
+    ///
+    /// Currently used in the app
     #[prost(message, optional, tag = "24")]
     pub home_view_v3: ::core::option::Option<HomeViewV3>,
+    /// The list of all titles, v2 implementation
+    ///
+    /// Currently used in the app
     #[prost(message, optional, tag = "25")]
     pub all_titles_v2: ::core::option::Option<TitleListOnlyV2>,
+    /// User settings information, v2 implementation
+    ///
+    /// Currently used in the app
     #[prost(message, optional, tag = "26")]
     pub user_settings_v2: ::core::option::Option<UserSettingsV2>,
+    /// The latest title updates, v2 implementation
+    ///
+    /// Currently used in the app
     #[prost(message, optional, tag = "27")]
     pub title_updates_v2: ::core::option::Option<TitleUpdatesV2>,
+    /// Initial view response, used when booting up the app, v2 implementation
+    ///
+    /// Currently used in the app
     #[prost(message, optional, tag = "28")]
     pub initial_view_v2: ::core::option::Option<InitialViewV2>,
+    /// The list of available languages
     #[prost(message, optional, tag = "29")]
     pub languages: ::core::option::Option<Languages>,
+    /// The web version of homepage view, v2 implementation
     #[prost(message, optional, tag = "30")]
     pub web_home_view_v2: ::core::option::Option<WebHomeViewV2>,
+    /// The web version of homepage view, v3 implementation
     #[prost(message, optional, tag = "31")]
     pub web_home_view_v3: ::core::option::Option<WebHomeViewV3>,
+    /// Push token information, used for notification
     #[prost(message, optional, tag = "32")]
     pub push_token: ::core::option::Option<PushTokenResponse>,
+    /// The list of available or free titles to read
     #[prost(message, optional, tag = "33")]
     pub free_titles: ::core::option::Option<FreeTitles>,
+    /// A list of labelled titles
+    ///
+    /// Currently unknown where this is used
     #[prost(message, optional, tag = "34")]
     pub labelled_titles: ::core::option::Option<LabelledTitles>,
+    /// The search results response
     #[prost(message, optional, tag = "35")]
     pub search_results: ::core::option::Option<SearchResults>,
+    /// The user subscription information and all the available subscription
     #[prost(message, optional, tag = "36")]
     pub subscriptions: ::core::option::Option<SubscriptionResponse>,
+    /// Title ranking information, v2 implementation
+    ///
+    /// Currently used in the app
     #[prost(message, optional, tag = "37")]
     pub title_ranking_v2: ::core::option::Option<TitleRankingList>,
+    /// The web version of homepage view, v4 implementation
+    ///
+    /// Currently used in the web version
     #[prost(message, optional, tag = "38")]
     pub web_home_view_v4: ::core::option::Option<WebHomeViewV4>,
+    /// The list of featured titles, v2 implementation
+    ///
+    /// Currently used in the app
     #[prost(message, optional, tag = "39")]
     pub featured_titles_v2: ::core::option::Option<FeaturedTitlesV2>,
 }
@@ -116,15 +176,21 @@ pub struct SuccessResponse {
 /// This is used like `oneOf` in Protobuf so only one of them will be available.
 #[derive(Clone, PartialEq, ::prost::Oneof)]
 pub enum SuccessOrError {
+    /// A [`Box`]-ed [`SuccessResponse`]
+    ///
+    /// Depending on the API request, only some of them
+    /// would be available to be used.
     #[prost(message, tag = "1")]
     Success(Box<SuccessResponse>),
+    /// A [`Box`]-ed [`ErrorResponse`]
     #[prost(message, tag = "2")]
     Error(Box<ErrorResponse>),
 }
 
 /// Proto response from the API, wrap a simple `oneOf` of [`SuccessOrError`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct Response {
+    /// The one-of API response data
     #[prost(oneof = "SuccessOrError", tags = "1, 2")]
     pub response: ::core::option::Option<SuccessOrError>,
 }

--- a/tosho_mplus/src/proto/mod.rs
+++ b/tosho_mplus/src/proto/mod.rs
@@ -9,6 +9,8 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![warn(clippy::missing_docs_in_private_items)]
 
+use tosho_macros::AutoGetter;
+
 pub mod accounts;
 pub mod chapters;
 pub mod comments;
@@ -26,149 +28,149 @@ pub use enums::*;
 pub use home_view::*;
 pub use others::*;
 pub use titles::*;
-use tosho_macros::AutoGetter;
 
 /// Indicate a success response
 ///
 /// Depending on the request type, not all field will be available.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
+#[auto_getters(cloned = true)]
 pub struct SuccessResponse {
     /// Is this a featured manga request or this have featured manga list
     #[prost(bool, optional, tag = "1")]
-    // #[auto_getters(skip_field)]
-    pub featured: ::core::option::Option<bool>,
+    #[skip_field]
+    featured: ::core::option::Option<bool>,
     /// Registration response information
     #[prost(message, optional, tag = "2")]
-    pub registration: ::core::option::Option<RegistrationData>,
+    registration: ::core::option::Option<RegistrationData>,
     /// The homepage view, v1 implementation
     #[prost(message, optional, tag = "3")]
-    pub home_view: ::core::option::Option<HomeView>,
+    home_view: ::core::option::Option<HomeView>,
     /// The list of featured titles
     #[prost(message, optional, tag = "4")]
-    pub featured_titles: ::core::option::Option<FeaturedTitles>,
+    featured_titles: ::core::option::Option<FeaturedTitles>,
     /// The list of all titles
     #[prost(message, optional, tag = "5")]
-    pub all_titles: ::core::option::Option<TitleListOnly>,
+    all_titles: ::core::option::Option<TitleListOnly>,
     /// The list of titles ranked depending on the request
     #[prost(message, optional, tag = "6")]
-    pub title_ranking: ::core::option::Option<TitleListOnly>,
+    title_ranking: ::core::option::Option<TitleListOnly>,
     /// The current user subscribed ro favorited titles
     #[prost(message, optional, tag = "7")]
-    pub subscribed_titles: ::core::option::Option<TitleListOnly>,
+    subscribed_titles: ::core::option::Option<TitleListOnly>,
     /// Information about a title
     #[prost(message, optional, tag = "8")]
-    pub title_detail: ::core::option::Option<TitleDetail>,
+    title_detail: ::core::option::Option<TitleDetail>,
     /// The list of comments on a chapter
     #[prost(message, optional, tag = "9")]
-    pub comment_list: ::core::option::Option<CommentList>,
+    comment_list: ::core::option::Option<CommentList>,
     /// The chapter viewer information
     #[prost(message, optional, tag = "10")]
-    pub chapter_viewer: ::core::option::Option<ChapterViewer>,
+    chapter_viewer: ::core::option::Option<ChapterViewer>,
     /// The web version of homepage view, v1 implementation
     #[prost(message, optional, tag = "11")]
-    pub web_home_view: ::core::option::Option<WebHomeView>,
+    web_home_view: ::core::option::Option<WebHomeView>,
     /// The user settings information
     #[prost(message, optional, tag = "12")]
-    pub user_settings: ::core::option::Option<UserSettings>,
+    user_settings: ::core::option::Option<UserSettings>,
     /// The user profile settings information
     #[prost(message, optional, tag = "13")]
-    pub user_profile_settings: ::core::option::Option<UserProfileSettings>,
+    user_profile_settings: ::core::option::Option<UserProfileSettings>,
     /// The update profile result
     #[prost(message, optional, tag = "14")]
-    pub update_profile_result: ::core::option::Option<UserUpdateProfileResult>,
+    update_profile_result: ::core::option::Option<UserUpdateProfileResult>,
     /// The current service announcement, usually used for maintenance notice
     #[prost(message, optional, tag = "15")]
-    pub service_announcements: ::core::option::Option<ServiceAnnouncements>,
+    service_announcements: ::core::option::Option<ServiceAnnouncements>,
     /// Initial view response, used when booting up the app
     #[prost(message, optional, tag = "16")]
-    pub initial_view: ::core::option::Option<InitialView>,
+    initial_view: ::core::option::Option<InitialView>,
     /// The feedback response
     #[prost(message, optional, tag = "17")]
-    pub feedback_view: ::core::option::Option<FeedbackList>,
+    feedback_view: ::core::option::Option<FeedbackList>,
     /// The publisher news list
     #[prost(message, optional, tag = "18")]
-    pub publisher_news_list: ::core::option::Option<PublisherNewsList>,
+    publisher_news_list: ::core::option::Option<PublisherNewsList>,
     /// Questionnaire response
     #[prost(message, optional, tag = "19")]
-    pub questionnaire: ::core::option::Option<QuestionnaireResponse>,
+    questionnaire: ::core::option::Option<QuestionnaireResponse>,
     /// The current title updates
     #[prost(message, optional, tag = "20")]
-    pub title_updates: ::core::option::Option<TitleUpdates>,
+    title_updates: ::core::option::Option<TitleUpdates>,
     /// The homepage view, v2 implementation
     #[prost(message, optional, tag = "21")]
-    pub home_view_v2: ::core::option::Option<HomeViewV2>,
+    home_view_v2: ::core::option::Option<HomeViewV2>,
     /// The updated titles list
     #[prost(message, optional, tag = "22")]
-    pub updated_titles: ::core::option::Option<UpdatedTitleList>,
+    updated_titles: ::core::option::Option<UpdatedTitleList>,
     /// Title that can be read with tickets
     #[prost(message, optional, tag = "23")]
-    pub title_tickets: ::core::option::Option<TitleTicketList>,
+    title_tickets: ::core::option::Option<TitleTicketList>,
     /// The homepage view, v3 implementation
     ///
     /// Currently used in the app
     #[prost(message, optional, tag = "24")]
-    pub home_view_v3: ::core::option::Option<HomeViewV3>,
+    home_view_v3: ::core::option::Option<HomeViewV3>,
     /// The list of all titles, v2 implementation
     ///
     /// Currently used in the app
     #[prost(message, optional, tag = "25")]
-    pub all_titles_v2: ::core::option::Option<TitleListOnlyV2>,
+    all_titles_v2: ::core::option::Option<TitleListOnlyV2>,
     /// User settings information, v2 implementation
     ///
     /// Currently used in the app
     #[prost(message, optional, tag = "26")]
-    pub user_settings_v2: ::core::option::Option<UserSettingsV2>,
+    user_settings_v2: ::core::option::Option<UserSettingsV2>,
     /// The latest title updates, v2 implementation
     ///
     /// Currently used in the app
     #[prost(message, optional, tag = "27")]
-    pub title_updates_v2: ::core::option::Option<TitleUpdatesV2>,
+    title_updates_v2: ::core::option::Option<TitleUpdatesV2>,
     /// Initial view response, used when booting up the app, v2 implementation
     ///
     /// Currently used in the app
     #[prost(message, optional, tag = "28")]
-    pub initial_view_v2: ::core::option::Option<InitialViewV2>,
+    initial_view_v2: ::core::option::Option<InitialViewV2>,
     /// The list of available languages
     #[prost(message, optional, tag = "29")]
-    pub languages: ::core::option::Option<Languages>,
+    languages: ::core::option::Option<Languages>,
     /// The web version of homepage view, v2 implementation
     #[prost(message, optional, tag = "30")]
-    pub web_home_view_v2: ::core::option::Option<WebHomeViewV2>,
+    web_home_view_v2: ::core::option::Option<WebHomeViewV2>,
     /// The web version of homepage view, v3 implementation
     #[prost(message, optional, tag = "31")]
-    pub web_home_view_v3: ::core::option::Option<WebHomeViewV3>,
+    web_home_view_v3: ::core::option::Option<WebHomeViewV3>,
     /// Push token information, used for notification
     #[prost(message, optional, tag = "32")]
-    pub push_token: ::core::option::Option<PushTokenResponse>,
+    push_token: ::core::option::Option<PushTokenResponse>,
     /// The list of available or free titles to read
     #[prost(message, optional, tag = "33")]
-    pub free_titles: ::core::option::Option<FreeTitles>,
+    free_titles: ::core::option::Option<FreeTitles>,
     /// A list of labelled titles
     ///
     /// Currently unknown where this is used
     #[prost(message, optional, tag = "34")]
-    pub labelled_titles: ::core::option::Option<LabelledTitles>,
+    labelled_titles: ::core::option::Option<LabelledTitles>,
     /// The search results response
     #[prost(message, optional, tag = "35")]
-    pub search_results: ::core::option::Option<SearchResults>,
+    search_results: ::core::option::Option<SearchResults>,
     /// The user subscription information and all the available subscription
     #[prost(message, optional, tag = "36")]
-    pub subscriptions: ::core::option::Option<SubscriptionResponse>,
+    subscriptions: ::core::option::Option<SubscriptionResponse>,
     /// Title ranking information, v2 implementation
     ///
     /// Currently used in the app
     #[prost(message, optional, tag = "37")]
-    pub title_ranking_v2: ::core::option::Option<TitleRankingList>,
+    title_ranking_v2: ::core::option::Option<TitleRankingList>,
     /// The web version of homepage view, v4 implementation
     ///
     /// Currently used in the web version
     #[prost(message, optional, tag = "38")]
-    pub web_home_view_v4: ::core::option::Option<WebHomeViewV4>,
+    web_home_view_v4: ::core::option::Option<WebHomeViewV4>,
     /// The list of featured titles, v2 implementation
     ///
     /// Currently used in the app
     #[prost(message, optional, tag = "39")]
-    pub featured_titles_v2: ::core::option::Option<FeaturedTitlesV2>,
+    featured_titles_v2: ::core::option::Option<FeaturedTitlesV2>,
 }
 
 /// A success or error response enum
@@ -192,5 +194,6 @@ pub enum SuccessOrError {
 pub struct Response {
     /// The one-of API response data
     #[prost(oneof = "SuccessOrError", tags = "1, 2")]
-    pub response: ::core::option::Option<SuccessOrError>,
+    #[deref_clone]
+    response: ::core::option::Option<SuccessOrError>,
 }

--- a/tosho_mplus/src/proto/others.rs
+++ b/tosho_mplus/src/proto/others.rs
@@ -4,110 +4,115 @@
 
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+use tosho_macros::AutoGetter;
+
 use super::AvailableLanguages;
 
 /// A service announcement
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct ServiceAnnouncement {
     /// The announcement title
     #[prost(string, tag = "1")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
     /// The announcement body
     #[prost(string, tag = "2")]
-    pub body: ::prost::alloc::string::String,
+    body: ::prost::alloc::string::String,
     /// The announcement timestamp
     #[prost(int64, tag = "3")]
-    pub timestamp: i64,
+    timestamp: i64,
     /// The annnouncement ID
     #[prost(uint64, tag = "4")]
-    pub id: u64,
+    id: u64,
 }
 
 /// A list of service announcements
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct ServiceAnnouncements {
     /// The list of announcements
     #[prost(message, repeated, tag = "1")]
-    pub announcements: ::prost::alloc::vec::Vec<ServiceAnnouncement>,
+    announcements: ::prost::alloc::vec::Vec<ServiceAnnouncement>,
 }
 
 /// A feedback response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct Feedback {
     /// The feedback creation timestamp
     #[prost(int64, tag = "1")]
-    pub timestamp: i64,
+    timestamp: i64,
     /// The feedback content
     #[prost(string, tag = "2")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
     /// The feedback type
     #[prost(enumeration = "super::FeedbackType", tag = "3")]
-    pub kind: i32,
+    #[skip_field]
+    kind: i32,
 }
 
 /// A list of feedback
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct FeedbackList {
     /// The list of feedback
     #[prost(message, repeated, tag = "1")]
-    pub feedbacks: ::prost::alloc::vec::Vec<Feedback>,
+    feedbacks: ::prost::alloc::vec::Vec<Feedback>,
 }
 
 /// Publisher news list response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct PublisherNewsList {
     /// The publisher ID
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// The publisher name
     #[prost(string, tag = "2")]
-    pub name: ::prost::alloc::string::String,
+    name: ::prost::alloc::string::String,
     /// The publisher banner
     #[prost(message, optional, tag = "3")]
-    pub banner: ::core::option::Option<super::common::Banner>,
+    banner: ::core::option::Option<super::common::Banner>,
     /// The list of news
     #[prost(message, repeated, tag = "4")]
-    pub news: ::prost::alloc::vec::Vec<super::common::PublisherNews>,
+    news: ::prost::alloc::vec::Vec<super::common::PublisherNews>,
 }
 
 /// A single questionnaire
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct Questionnaire {
     /// The question
     #[prost(string, tag = "1")]
-    pub question: ::prost::alloc::string::String,
+    question: ::prost::alloc::string::String,
     /// The selection of answers
     #[prost(string, repeated, tag = "2")]
-    pub answers: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    answers: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Total number of choices
     #[prost(uint64, tag = "3")]
-    pub total_choices: u64,
+    total_choices: u64,
     /// Hide free form answer
     #[prost(bool, tag = "4")]
-    pub hide_free_form: bool,
+    hide_free_form: bool,
     /// Free form answer
     #[prost(string, optional, tag = "5")]
-    pub free_form: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    free_form: ::core::option::Option<::prost::alloc::string::String>,
     /// Can skip the question or not
     #[prost(bool, tag = "6")]
-    pub can_skip: bool,
+    can_skip: bool,
 }
 
 /// A questionnaire response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct QuestionnaireResponse {
     /// Is this questionnaire answered already?
     #[prost(bool, tag = "1")]
-    pub answered: bool,
+    answered: bool,
     /// The subject of the questionnaire
     #[prost(string, tag = "2")]
-    pub subject: ::prost::alloc::string::String,
+    subject: ::prost::alloc::string::String,
     /// The list of questions
     #[prost(message, repeated, tag = "3")]
-    pub questions: ::prost::alloc::vec::Vec<Questionnaire>,
+    questions: ::prost::alloc::vec::Vec<Questionnaire>,
     /// The language of the questionnaire
     #[prost(enumeration = "super::Language", tag = "4")]
-    pub language: i32,
+    #[skip_field]
+    language: i32,
 }
 
 /// The response for initial view of the app
@@ -115,17 +120,17 @@ pub struct QuestionnaireResponse {
 /// The following is `v1` implementation of the initial view response.
 ///
 /// See also: [`InitialView`]
-#[derive(Clone, PartialEq, Copy, ::prost::Message)]
+#[derive(Clone, Copy, AutoGetter, PartialEq, ::prost::Message)]
 pub struct InitialView {
     /// Should the user agree to the GDPR or not
     #[prost(bool, tag = "1")]
-    pub gdpr_required: bool,
+    gdpr_required: bool,
     /// Total of english translated titles
     #[prost(uint64, tag = "2")]
-    pub english_titles: u64,
+    english_titles: u64,
     /// Total of spanish translated titles
     #[prost(uint64, tag = "3")]
-    pub spanish_titles: u64,
+    spanish_titles: u64,
 }
 
 /// The response for intial view of the app
@@ -133,63 +138,63 @@ pub struct InitialView {
 /// The following is `v2` implementation of the initial view response.
 ///
 /// See also: [`InitialView`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct InitialViewV2 {
     /// Should the user agree to the GDPR or not
     #[prost(bool, tag = "1")]
-    pub gdpr_required: bool,
+    gdpr_required: bool,
     /// A list of available languages and titles count
     #[prost(message, repeated, tag = "2")]
-    pub languages: ::prost::alloc::vec::Vec<AvailableLanguages>,
+    languages: ::prost::alloc::vec::Vec<AvailableLanguages>,
 }
 
 /// The search contents
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct SearchContents {
     /// The banner for search
     #[prost(message, optional, tag = "1")]
-    pub banner: ::core::option::Option<super::common::Banner>,
+    banner: ::core::option::Option<super::common::Banner>,
     /// The list titles that match the search
     #[prost(message, repeated, tag = "2")]
-    pub titles: ::prost::alloc::vec::Vec<super::titles::TitleList>,
+    titles: ::prost::alloc::vec::Vec<super::titles::TitleList>,
     /// The ranked titles
     #[prost(message, repeated, tag = "3")]
-    pub rankings: ::prost::alloc::vec::Vec<super::titles::TitleRankingGroup>,
+    rankings: ::prost::alloc::vec::Vec<super::titles::TitleRankingGroup>,
     /// All the labels for this content
     #[prost(message, repeated, tag = "4")]
-    pub labels: ::prost::alloc::vec::Vec<super::common::Label>,
+    labels: ::prost::alloc::vec::Vec<super::common::Label>,
 }
 
 /// The response for search result
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct SearchResults {
     /// The top search banners
     #[prost(message, repeated, tag = "1")]
-    pub top_banners: ::prost::alloc::vec::Vec<super::common::Banner>,
+    top_banners: ::prost::alloc::vec::Vec<super::common::Banner>,
     /// The list of tags that can be used on the search
     #[prost(message, repeated, tag = "2")]
-    pub tags: ::prost::alloc::vec::Vec<super::common::Tag>,
+    tags: ::prost::alloc::vec::Vec<super::common::Tag>,
     /// The list of titles that match the search
     #[prost(message, repeated, tag = "3")]
-    pub titles: ::prost::alloc::vec::Vec<super::titles::TitleListV2>,
+    titles: ::prost::alloc::vec::Vec<super::titles::TitleListV2>,
     /// The list of search results contents
     #[prost(message, repeated, tag = "5")]
-    pub contents: ::prost::alloc::vec::Vec<SearchContents>,
+    contents: ::prost::alloc::vec::Vec<SearchContents>,
 }
 
 /// The subscriptions list response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct SubscriptionResponse {
     /// The user subscription
     #[prost(message, optional, tag = "1")]
-    pub subscription: ::core::option::Option<super::accounts::UserSubscription>,
+    subscription: ::core::option::Option<super::accounts::UserSubscription>,
     /// The available plans
     #[prost(message, repeated, tag = "2")]
-    pub plans: ::prost::alloc::vec::Vec<super::common::Plan>,
+    plans: ::prost::alloc::vec::Vec<super::common::Plan>,
     /// The available titles for each plans
     #[prost(message, repeated, tag = "3")]
-    pub titles: ::prost::alloc::vec::Vec<super::titles::SubscriptionTitles>,
+    titles: ::prost::alloc::vec::Vec<super::titles::SubscriptionTitles>,
     /// User has already used the free trial
     #[prost(bool, tag = "4")]
-    pub free_trial_used: bool,
+    free_trial_used: bool,
 }

--- a/tosho_mplus/src/proto/titles.rs
+++ b/tosho_mplus/src/proto/titles.rs
@@ -4,6 +4,8 @@
 
 use std::str::FromStr;
 
+use tosho_macros::AutoGetter;
+
 use crate::helper::SubscriptionPlan;
 
 use super::{
@@ -12,136 +14,144 @@ use super::{
 };
 
 /// A single title information
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct Title {
     /// The title ID
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// The title name
     #[prost(string, tag = "2")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
     /// The title author
     #[prost(string, tag = "3")]
-    pub author: ::prost::alloc::string::String,
+    author: ::prost::alloc::string::String,
     /// The portrait image URL
     #[prost(string, tag = "4")]
-    pub portrait: ::prost::alloc::string::String,
+    portrait: ::prost::alloc::string::String,
     /// The landscape image URL
     #[prost(string, tag = "5")]
-    pub landscape: ::prost::alloc::string::String,
+    landscape: ::prost::alloc::string::String,
     /// The view count of the title
     #[prost(uint64, tag = "6")]
-    pub view_count: u64,
+    view_count: u64,
     /// The language of the title
     #[prost(enumeration = "Language", tag = "7")]
-    pub language: i32,
+    #[skip_field]
+    language: i32,
     /// The title status
     #[prost(enumeration = "TitleUpdateStatus", tag = "8")]
-    pub status: i32,
+    #[skip_field]
+    status: i32,
 }
 
 /// A detailed title information
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleDetail {
     /// The title information
     #[prost(message, tag = "1")]
-    pub title: ::core::option::Option<Title>,
+    title: ::core::option::Option<Title>,
     /// The title image URL
     #[prost(string, tag = "2")]
-    pub image: ::prost::alloc::string::String,
+    image: ::prost::alloc::string::String,
     /// The title overview/description
     #[prost(string, tag = "3")]
-    pub overview: ::prost::alloc::string::String,
+    overview: ::prost::alloc::string::String,
     /// The background image URL
     #[prost(string, tag = "4")]
-    pub background_image: ::prost::alloc::string::String,
+    background_image: ::prost::alloc::string::String,
     /// Next update UNIX timestamp
     #[prost(int64, optional, tag = "5")]
-    pub next_update: ::core::option::Option<i64>,
+    #[skip_field]
+    next_update: ::core::option::Option<i64>,
     /// Update frequency in seconds
     #[prost(uint64, optional, tag = "6")]
-    pub update_frequency: ::core::option::Option<u64>,
+    #[skip_field]
+    update_frequency: ::core::option::Option<u64>,
     /// Viewing period description
     #[prost(string, optional, tag = "7")]
-    pub viewing_period: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    viewing_period: ::core::option::Option<::prost::alloc::string::String>,
     /// Non-appereance message
     #[prost(string, optional, tag = "8")]
-    pub non_appearance_message: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    non_appearance_message: ::core::option::Option<::prost::alloc::string::String>,
     /// A list of first chapters that can be read
     #[prost(message, repeated, tag = "9")]
-    pub first_chapters: ::prost::alloc::vec::Vec<Chapter>,
+    first_chapters: ::prost::alloc::vec::Vec<Chapter>,
     /// A list of last chapters that can be read
     #[prost(message, repeated, tag = "10")]
-    pub last_chapters: ::prost::alloc::vec::Vec<Chapter>,
+    last_chapters: ::prost::alloc::vec::Vec<Chapter>,
     /// A list of banners
     #[prost(message, repeated, tag = "11")]
-    pub banners: ::prost::alloc::vec::Vec<Banner>,
+    banners: ::prost::alloc::vec::Vec<Banner>,
     /// A list of recommended titles
     #[prost(message, repeated, tag = "12")]
-    pub recommended_titles: ::prost::alloc::vec::Vec<Title>,
+    recommended_titles: ::prost::alloc::vec::Vec<Title>,
     // SNS field: 13
     /// Is the title simulpublished with the original release?
     #[prost(bool, tag = "14")]
-    pub simulpublish: bool,
+    simulpublish: bool,
     /// Is the user subscribed to this title?
     #[prost(bool, tag = "15")]
-    pub subscribed: bool,
+    subscribed: bool,
     /// The title rating
     #[prost(enumeration = "super::TitleRating", tag = "16")]
-    pub rating: i32,
+    #[skip_field]
+    rating: i32,
     /// Is the chapters in descending order?
     #[prost(bool, tag = "17")]
-    pub descending: bool,
+    descending: bool,
     /// The title number of views
     #[prost(uint64, tag = "18")]
-    pub view_count: u64,
+    view_count: u64,
     /// Publisher items
     #[prost(message, repeated, tag = "19")]
-    pub publishers: ::prost::alloc::vec::Vec<PublisherItem>,
+    publishers: ::prost::alloc::vec::Vec<PublisherItem>,
     /// Title banners
     #[prost(message, repeated, tag = "20")]
-    pub title_banners: ::prost::alloc::vec::Vec<Banner>,
+    title_banners: ::prost::alloc::vec::Vec<Banner>,
     /// User tikcet information
     #[prost(message, optional, tag = "21")]
-    pub user_tickets: ::core::option::Option<UserTickets>,
+    #[copyable]
+    user_tickets: ::core::option::Option<UserTickets>,
     /// Chapter that can be claimed with ticket
     #[prost(message, repeated, tag = "22")]
-    pub ticket_chapters: ::prost::alloc::vec::Vec<Chapter>,
+    ticket_chapters: ::prost::alloc::vec::Vec<Chapter>,
     /// Ticket title list
     #[prost(message, repeated, tag = "23")]
-    pub ticket_titles: ::prost::alloc::vec::Vec<Title>,
+    ticket_titles: ::prost::alloc::vec::Vec<Title>,
     /// Has a chapter in-between
     #[prost(bool, tag = "24")]
-    pub has_in_between: bool,
+    has_in_between: bool,
     /// Publisher banner
     #[prost(message, optional, tag = "25")]
-    pub publisher_banner: ::core::option::Option<Banner>,
+    publisher_banner: ::core::option::Option<Banner>,
     // Ads field: 26
     /// Other languages available for the title
     #[prost(message, repeated, tag = "27")]
-    pub other_languages: ::prost::alloc::vec::Vec<TitleLanguages>,
+    other_languages: ::prost::alloc::vec::Vec<TitleLanguages>,
     /// Grouped chapters list
     #[prost(message, repeated, tag = "28")]
-    pub chapter_groups: ::prost::alloc::vec::Vec<ChapterGroup>,
+    chapter_groups: ::prost::alloc::vec::Vec<ChapterGroup>,
     // Free dialogue view: 29
     /// Region code of the title
     #[prost(string, tag = "30")]
-    pub region_code: ::prost::alloc::string::String,
+    region_code: ::prost::alloc::string::String,
     /// Tags of the title
     #[prost(message, repeated, tag = "31")]
-    pub tags: ::prost::alloc::vec::Vec<Tag>,
+    tags: ::prost::alloc::vec::Vec<Tag>,
     /// Specific label applied to the title
     #[prost(message, tag = "32")]
-    pub title_labels: ::core::option::Option<TitleLabels>,
+    title_labels: ::core::option::Option<TitleLabels>,
     /// User subscription information
     #[prost(message, optional, tag = "33")]
-    pub user_subscription: ::core::option::Option<UserSubscription>,
+    user_subscription: ::core::option::Option<UserSubscription>,
     /// Label applied to the title
     #[prost(message, optional, tag = "34")]
-    pub label: ::core::option::Option<Label>,
+    label: ::core::option::Option<Label>,
     /// Is the first time reading would be free?
     #[prost(bool, tag = "35")]
-    pub first_time_free: bool,
+    first_time_free: bool,
 }
 
 impl TitleDetail {
@@ -152,31 +162,39 @@ impl TitleDetail {
             .flat_map(|group| group.flatten())
             .collect()
     }
+
+    /// A mutable reference to chapters group
+    pub fn chapter_groups_mut(&mut self) -> &mut Vec<ChapterGroup> {
+        &mut self.chapter_groups
+    }
 }
 
 /// An information about a title with available languages
-#[derive(Clone, PartialEq, Copy, ::prost::Message)]
+#[derive(Clone, Copy, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleLanguages {
     /// Title ID
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// Title language
     #[prost(enumeration = "Language", tag = "2")]
-    pub language: i32,
+    #[skip_field]
+    language: i32,
 }
 
 /// Title labels information
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleLabels {
     /// Release schedule of the title
     #[prost(enumeration = "super::TitleReleaseSchedule", tag = "1")]
-    pub release_schedule: i32,
+    #[skip_field]
+    release_schedule: i32,
     /// Is the title simulpublished with the original release?
     #[prost(bool, tag = "2")]
-    pub simulpublish: bool,
+    simulpublish: bool,
     /// Plan type of the title
     #[prost(string, tag = "3")]
-    pub plan_type: ::prost::alloc::string::String,
+    #[skip_field]
+    plan_type: ::prost::alloc::string::String,
 }
 
 impl TitleLabels {
@@ -197,14 +215,14 @@ impl TitleLabels {
 /// This is a `v1` implementation of the title list.
 ///
 /// See also: [`TitleListV2`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleList {
     /// The group name
     #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
+    name: ::prost::alloc::string::String,
     /// The list of titles
     #[prost(message, repeated, tag = "2")]
-    pub titles: ::prost::alloc::vec::Vec<Title>,
+    titles: ::prost::alloc::vec::Vec<Title>,
 }
 
 /// A list of titles contained into a group
@@ -212,23 +230,24 @@ pub struct TitleList {
 /// This is a `v2` implementation of the title list.
 ///
 /// See also: [`TitleList`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleListV2 {
     /// The group name
     #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
+    name: ::prost::alloc::string::String,
     /// The list of titles
     #[prost(message, repeated, tag = "2")]
-    pub titles: ::prost::alloc::vec::Vec<Title>,
+    titles: ::prost::alloc::vec::Vec<Title>,
     /// The group tags
     #[prost(message, repeated, tag = "3")]
-    pub tags: ::prost::alloc::vec::Vec<Tag>,
+    tags: ::prost::alloc::vec::Vec<Tag>,
     /// The group label
     #[prost(message, optional, tag = "4")]
-    pub label: ::core::option::Option<Label>,
+    label: ::core::option::Option<Label>,
     /// The next chapter start timestamp
     #[prost(int64, optional, tag = "5")]
-    pub next_start_at: ::core::option::Option<i64>,
+    #[skip_field]
+    next_start_at: ::core::option::Option<i64>,
 }
 
 /// A list of titles with no grouping information
@@ -236,11 +255,11 @@ pub struct TitleListV2 {
 /// This is a `v1` implementation of the title list.
 ///
 /// See also: [`TitleListOnlyV2`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleListOnly {
     /// The list of titles
     #[prost(message, repeated, tag = "1")]
-    pub titles: ::prost::alloc::vec::Vec<Title>,
+    titles: ::prost::alloc::vec::Vec<Title>,
 }
 
 /// A list of titles with no grouping information
@@ -248,37 +267,39 @@ pub struct TitleListOnly {
 /// This is a `v2` implementation of the title list.
 ///
 /// See also: [`TitleListOnly`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleListOnlyV2 {
     /// The list of titles
     #[prost(message, repeated, tag = "1")]
-    pub titles: ::prost::alloc::vec::Vec<TitleListV2>,
+    titles: ::prost::alloc::vec::Vec<TitleListV2>,
 }
 
 /// An updated title information
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct UpdatedTitle {
     /// The title itself that got updated
     #[prost(message, tag = "1")]
-    pub title: ::core::option::Option<Title>,
+    title: ::core::option::Option<Title>,
     /// Chapter ID that got updated
     #[prost(uint64, tag = "2")]
-    pub chapter_id: u64,
+    chapter_id: u64,
     /// The chapter title
     #[prost(string, optional, tag = "3")]
-    pub chapter_title: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    chapter_title: ::core::option::Option<::prost::alloc::string::String>,
     /// The chapter subtitle
     #[prost(string, optional, tag = "4")]
-    pub chapter_subtitle: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    chapter_subtitle: ::core::option::Option<::prost::alloc::string::String>,
     /// Is chapter is latest chapter update or not.
     #[prost(bool, tag = "5")]
-    pub latest: bool,
+    latest: bool,
     /// Does the chapter can only be read in long-strip mode only.
     #[prost(bool, tag = "6")]
-    pub long_strip_only: bool,
+    long_strip_only: bool,
     /// Does the chapter can only be read in horizontal mode only.
     #[prost(bool, tag = "7")]
-    pub horizontal_only: bool,
+    horizontal_only: bool,
 }
 
 /// A list of updated titles grouped by something
@@ -286,47 +307,48 @@ pub struct UpdatedTitle {
 /// The following is `v1` implementation of the updated title group.
 ///
 /// See also: [`UpdatedTitleGroupV2`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct UpdatedTitleGroup {
     /// The group name
     #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
+    name: ::prost::alloc::string::String,
     /// The list of updated titles
     #[prost(message, repeated, tag = "2")]
-    pub titles: ::prost::alloc::vec::Vec<UpdatedTitle>,
+    titles: ::prost::alloc::vec::Vec<UpdatedTitle>,
 }
 
 /// A list of grouped updated titles
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct UpdatedTitleList {
     /// The list of updated titles
     #[prost(message, repeated, tag = "1")]
-    pub updates: ::prost::alloc::vec::Vec<UpdatedTitleGroup>,
+    updates: ::prost::alloc::vec::Vec<UpdatedTitleGroup>,
 }
 
 /// An original implementation for updated title group
 ///
 /// See also: [`UpdatedTitleGroupV2`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct UpdatedTitleGroupOriginal {
     /// The title group name
     #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
+    name: ::prost::alloc::string::String,
     /// The chapter number of it
     #[prost(string, tag = "2")]
-    pub chapter_number: ::prost::alloc::string::String,
+    chapter_number: ::prost::alloc::string::String,
     /// The list of updated titles
     #[prost(message, repeated, tag = "3")]
-    pub titles: ::prost::alloc::vec::Vec<UpdatedTitle>,
+    titles: ::prost::alloc::vec::Vec<UpdatedTitle>,
     /// View count of the title
     #[prost(uint64, tag = "4")]
-    pub view_count: u64,
+    view_count: u64,
     /// Title update status
     #[prost(enumeration = "TitleUpdateStatus", tag = "5")]
-    pub status: i32,
+    #[skip_field]
+    status: i32,
     /// Chapter start timestamp
     #[prost(int64, tag = "6")]
-    pub start_at: i64,
+    start_at: i64,
 }
 
 /// A list of updated titles grouped by something
@@ -334,17 +356,17 @@ pub struct UpdatedTitleGroupOriginal {
 /// The following is `v2` implementation of the updated title group.
 ///
 /// See also: [`UpdatedTitleGroup`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct UpdatedTitleGroupV2 {
     /// The group name
     #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
+    name: ::prost::alloc::string::String,
     /// The titles in the group
     #[prost(message, repeated, tag = "2")]
-    pub titles: ::prost::alloc::vec::Vec<UpdatedTitleGroupOriginal>,
+    titles: ::prost::alloc::vec::Vec<UpdatedTitleGroupOriginal>,
     /// The group name days
     #[prost(uint64, tag = "3")]
-    pub days: u64,
+    days: u64,
 }
 
 /// The detailed contents of the featured titles
@@ -352,14 +374,14 @@ pub struct UpdatedTitleGroupV2 {
 /// This is `v1` implementation of the featured title contents.
 ///
 /// See also: [`FeaturedTitleContentsV2`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct FeaturedTitleContents {
     /// The featured banner contents
     #[prost(message, optional, tag = "1")]
-    pub banner: ::core::option::Option<Banner>,
+    banner: ::core::option::Option<Banner>,
     /// A list of featured titles
     #[prost(message, optional, tag = "2")]
-    pub titles: ::core::option::Option<TitleList>,
+    titles: ::core::option::Option<TitleList>,
 }
 
 /// A list of featured titles
@@ -367,20 +389,20 @@ pub struct FeaturedTitleContents {
 /// This is `v1` implementation of the featured titles.
 ///
 /// See also: [`FeaturedTitlesV2`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct FeaturedTitles {
     /// The main featured title
     #[prost(message, optional, tag = "1")]
-    pub main: ::core::option::Option<Banner>,
+    main: ::core::option::Option<Banner>,
     /// The first sub featured title
     #[prost(message, optional, tag = "2")]
-    pub sub1: ::core::option::Option<Banner>,
+    sub1: ::core::option::Option<Banner>,
     /// The second sub featured title
     #[prost(message, optional, tag = "3")]
-    pub sub2: ::core::option::Option<Banner>,
+    sub2: ::core::option::Option<Banner>,
     /// The featured title contents
     #[prost(message, repeated, tag = "4")]
-    pub contents: ::prost::alloc::vec::Vec<FeaturedTitleContents>,
+    contents: ::prost::alloc::vec::Vec<FeaturedTitleContents>,
 }
 
 /// The detailed contents of the featured titles
@@ -388,17 +410,17 @@ pub struct FeaturedTitles {
 /// This is `v2` implementation of the featured title contents.
 ///
 /// See also: [`FeaturedTitleContents`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct FeaturedTitleContentsV2 {
     /// The featured banner contents
     #[prost(message, optional, tag = "1")]
-    pub banner: ::core::option::Option<Banner>,
+    banner: ::core::option::Option<Banner>,
     /// A list of featured titles
     #[prost(message, optional, tag = "2")]
-    pub titles: ::core::option::Option<TitleList>,
+    titles: ::core::option::Option<TitleList>,
     /// The ranked titles
     #[prost(message, repeated, tag = "3")]
-    pub ranked_titles: ::prost::alloc::vec::Vec<TitleRankingGroup>,
+    ranked_titles: ::prost::alloc::vec::Vec<TitleRankingGroup>,
 }
 
 /// A list of featured titles
@@ -406,45 +428,45 @@ pub struct FeaturedTitleContentsV2 {
 /// This is `v2` implementation of the featured titles.
 ///
 /// See also: [`FeaturedTitles`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct FeaturedTitlesV2 {
     /// The list of top search banners
     #[prost(message, repeated, tag = "1")]
-    pub banners: ::prost::alloc::vec::Vec<Banner>,
+    banners: ::prost::alloc::vec::Vec<Banner>,
     /// The featured title contents
     #[prost(message, repeated, tag = "4")]
-    pub contents: ::prost::alloc::vec::Vec<FeaturedTitleContentsV2>,
+    contents: ::prost::alloc::vec::Vec<FeaturedTitleContentsV2>,
 }
 
 /// A subscribed or favorited title information
 ///
 /// This also used as a history of recently read titles.
 /// If the title is not subscribed, you *can* assume it's a history.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct SubscribedTitle {
     /// The title itself
     #[prost(message, tag = "1")]
-    pub title: ::core::option::Option<Title>,
+    title: ::core::option::Option<Title>,
     /// Is there any latest chapter available?
     #[prost(bool, tag = "2")]
-    pub latest: bool,
+    latest: bool,
     /// Is this title subscribed?
     #[prost(bool, tag = "3")]
-    pub subscribed: bool,
+    subscribed: bool,
 }
 
 /// An upcoming chapter of a title
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct UpcomingChapterTitle {
     /// The title itself
     #[prost(message, tag = "1")]
-    pub title: ::core::option::Option<Title>,
+    title: ::core::option::Option<Title>,
     /// The next chapter name
     #[prost(string, tag = "2")]
-    pub chapter_name: ::prost::alloc::string::String,
+    chapter_name: ::prost::alloc::string::String,
     /// The next chapter release timestamp
     #[prost(int64, tag = "3")]
-    pub release_at: i64,
+    release_at: i64,
 }
 
 /// A single title update information
@@ -452,14 +474,14 @@ pub struct UpcomingChapterTitle {
 /// This is a `v1` implementation of the title update information.
 ///
 /// See also: [`TitleUpdatedV2`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleUpdated {
     /// The title itself
     #[prost(message, tag = "1")]
-    pub title: ::core::option::Option<Title>,
+    title: ::core::option::Option<Title>,
     /// The update timestamp
     #[prost(string, tag = "2")]
-    pub updated_at: ::prost::alloc::string::String,
+    updated_at: ::prost::alloc::string::String,
 }
 
 /// A single title update information
@@ -467,14 +489,14 @@ pub struct TitleUpdated {
 /// This is a `v2` implementation of the title update information.
 ///
 /// See also: [`TitleUpdated`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleUpdatedV2 {
     /// The titles
     #[prost(message, repeated, tag = "1")]
-    pub titles: ::prost::alloc::vec::Vec<TitleListV2>,
+    titles: ::prost::alloc::vec::Vec<TitleListV2>,
     /// The update timestamp
     #[prost(string, tag = "2")]
-    pub updated_at: ::prost::alloc::string::String,
+    updated_at: ::prost::alloc::string::String,
 }
 
 /// A list of title updates
@@ -482,11 +504,11 @@ pub struct TitleUpdatedV2 {
 /// This is a `v1` implementation of the title updates.
 ///
 /// See also: [`TitleUpdatesV2`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleUpdates {
     /// The list of title updates
     #[prost(message, repeated, tag = "1")]
-    pub updates: ::prost::alloc::vec::Vec<TitleUpdated>,
+    updates: ::prost::alloc::vec::Vec<TitleUpdated>,
 }
 
 /// A list of title updates
@@ -494,114 +516,114 @@ pub struct TitleUpdates {
 /// This is a `v2` implementation of the title updates.
 ///
 /// See also: [`TitleUpdates`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleUpdatesV2 {
     /// The list of title updates
     #[prost(message, repeated, tag = "1")]
-    pub updates: ::prost::alloc::vec::Vec<TitleUpdatedV2>,
+    updates: ::prost::alloc::vec::Vec<TitleUpdatedV2>,
 }
 
 /// An information about a title with tickets available
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleTicket {
     /// The title itself
     #[prost(message, tag = "1")]
-    pub title: ::core::option::Option<Title>,
+    title: ::core::option::Option<Title>,
     /// First chapter that can be read with ticket
     #[prost(uint64, tag = "2")]
-    pub first_chapter: u64,
+    first_chapter: u64,
     /// Last chapter that can be read with ticket
     #[prost(uint64, tag = "3")]
-    pub last_chapter: u64,
+    last_chapter: u64,
 }
 
 /// A list of titles with tickets available
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleTicketList {
     /// The list of titles with tickets
     #[prost(message, repeated, tag = "1")]
-    pub titles: ::prost::alloc::vec::Vec<TitleTicket>,
+    titles: ::prost::alloc::vec::Vec<TitleTicket>,
 }
 
 /// A title highlighted in the home view
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct HighlightedTitle {
     /// The title itself
     #[prost(message, tag = "1")]
-    pub title: ::core::option::Option<Title>,
+    title: ::core::option::Option<Title>,
     /// The associated chapter ID
     #[prost(uint64, tag = "2")]
-    pub chapter_id: u64,
+    chapter_id: u64,
     /// The list of page URL
     #[prost(string, repeated, tag = "3")]
-    pub pages: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pages: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// The page height
     #[prost(uint64, tag = "4")]
-    pub height: u64,
+    height: u64,
     /// The page width
     #[prost(uint64, tag = "5")]
-    pub width: u64,
+    width: u64,
     /// Is vertical only?
     #[prost(bool, tag = "6")]
-    pub vertical_only: bool,
+    vertical_only: bool,
     /// Is horizontal only?
     #[prost(bool, tag = "7")]
-    pub horizontal_only: bool,
+    horizontal_only: bool,
 }
 
 /// A free title to be read
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct FreeTitle {
     /// The title itself
     #[prost(message, tag = "1")]
-    pub title: ::core::option::Option<Title>,
+    title: ::core::option::Option<Title>,
     /// The updated timestamp of the title
     #[prost(string, tag = "2")]
-    pub updated_at: ::prost::alloc::string::String,
+    updated_at: ::prost::alloc::string::String,
 }
 
 /// A list of free titles
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct FreeTitles {
     /// The list of free titles
     #[prost(message, repeated, tag = "1")]
-    pub titles: ::prost::alloc::vec::Vec<FreeTitle>,
+    titles: ::prost::alloc::vec::Vec<FreeTitle>,
 }
 
 /// A label applied to a list of titles
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct LabelledTitle {
     /// The label title
     #[prost(string, tag = "1")]
-    pub label: ::prost::alloc::string::String,
+    label: ::prost::alloc::string::String,
     /// The list of titles
     #[prost(message, repeated, tag = "2")]
-    pub titles: ::prost::alloc::vec::Vec<Title>,
+    titles: ::prost::alloc::vec::Vec<Title>,
 }
 
 /// A list of titles with labels
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct LabelledTitles {
     /// The label itself
     #[prost(message, tag = "1")]
-    pub label: ::core::option::Option<Label>,
+    label: ::core::option::Option<Label>,
     /// The list of labelled titles
     #[prost(message, repeated, tag = "2")]
-    pub labels: ::prost::alloc::vec::Vec<LabelledTitle>,
+    labels: ::prost::alloc::vec::Vec<LabelledTitle>,
 }
 
 /// A title in ranking list
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleRankingGroup {
     /// Original title ID
     #[prost(uint64, tag = "1")]
-    pub original_title: u64,
+    original_title: u64,
     /// The titles in each available languages
     #[prost(message, repeated, tag = "2")]
-    pub titles: ::prost::alloc::vec::Vec<Title>,
+    titles: ::prost::alloc::vec::Vec<Title>,
     /// The ranking score/position
     #[prost(uint64, tag = "3")]
-    pub ranking: u64,
+    ranking: u64,
 }
 
 /// Title ranking list response
@@ -609,28 +631,29 @@ pub struct TitleRankingGroup {
 /// This is `v2` implementation of the title ranking list.
 ///
 /// See also: [`TitleListOnly`]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct TitleRankingList {
     /// The list of banners
     #[prost(message, repeated, tag = "1")]
-    pub banners: ::prost::alloc::vec::Vec<Banner>,
+    banners: ::prost::alloc::vec::Vec<Banner>,
     /// The updated timestamp of this ranking
     #[prost(int64, tag = "2")]
-    pub updated_at: i64,
+    updated_at: i64,
     /// The list of titles
     #[prost(message, repeated, tag = "3")]
-    pub titles: ::prost::alloc::vec::Vec<TitleRankingGroup>,
+    titles: ::prost::alloc::vec::Vec<TitleRankingGroup>,
 }
 
 /// A list of titles in subscriptions plan
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, AutoGetter, PartialEq, ::prost::Message)]
 pub struct SubscriptionTitles {
     /// The plan type
     #[prost(string, tag = "1")]
-    pub plan: ::prost::alloc::string::String,
+    #[skip_field]
+    plan: ::prost::alloc::string::String,
     /// The list of titles
     #[prost(message, repeated, tag = "2")]
-    pub titles: ::prost::alloc::vec::Vec<Title>,
+    titles: ::prost::alloc::vec::Vec<Title>,
 }
 
 impl SubscriptionTitles {

--- a/tosho_musq/src/constants.rs
+++ b/tosho_musq/src/constants.rs
@@ -134,9 +134,9 @@ pub static IMAGE_HOST: LazyLock<String> = LazyLock::new(|| {
 /// Panics if the device type is invalid.
 ///
 /// # Examples
-/// ```
-/// use tosho_musq::constants::get_constants;
-///
+/// ```rust
+/// # use tosho_musq::constants::get_constants;
+/// #
 /// let _ = get_constants(1); // Android
 /// let _ = get_constants(2); // Apple
 /// ```

--- a/tosho_musq/src/helper.rs
+++ b/tosho_musq/src/helper.rs
@@ -19,7 +19,7 @@ use chrono::Datelike;
 /// Used with [`crate::MUClient::get_weekly_titles`] to get manga updates for each week.
 ///
 /// # Example
-/// ```no_run
+/// ```rust,no_run
 /// use tosho_musq::{constants::get_constants, MUClient};
 ///
 /// let client = MUClient::new("123456", get_constants(1)).unwrap();
@@ -92,7 +92,7 @@ impl WeeklyCode {
     /// the corresponding [``WeeklyCode``] enum.
     ///
     /// # Example
-    /// ```
+    /// ```rust
     /// use tosho_musq::helper::WeeklyCode;
     ///
     /// let today = WeeklyCode::today();
@@ -114,7 +114,7 @@ impl WeeklyCode {
     /// Get the zero-based index of the day of the week.
     ///
     /// # Example
-    /// ```
+    /// ```rust
     /// use tosho_musq::helper::WeeklyCode;
     ///
     /// let monday = WeeklyCode::Monday;
@@ -138,7 +138,7 @@ impl WeeklyCode {
 /// Used with [`crate::MUClient::get_chapter_images`] to select image quality.
 ///
 /// # Example
-/// ```no_run
+/// ```rust,no_run
 /// use tosho_musq::{constants::get_constants, MUClient, ImageQuality};
 ///
 /// let client = MUClient::new("123456", get_constants(1)).unwrap();
@@ -183,7 +183,7 @@ impl std::fmt::Display for ImageQuality {
 /// Every attribute will default to 0.
 ///
 /// # Example
-/// ```
+/// ```rust
 /// use tosho_musq::ConsumeCoin;
 ///
 /// let coins = ConsumeCoin::new(1, 2, 3, 4);
@@ -214,7 +214,7 @@ impl ConsumeCoin {
     /// Check if the chapter can be purchased.
     ///
     /// # Example
-    /// ```
+    /// ```rust
     /// use tosho_musq::ConsumeCoin;
     ///
     /// let coins = ConsumeCoin::new(1, 2, 3, 4);
@@ -230,7 +230,7 @@ impl ConsumeCoin {
     /// Check if the chapter is free.
     ///
     /// # Example
-    /// ```
+    /// ```rust
     /// use tosho_musq::ConsumeCoin;
     ///
     /// let coins = ConsumeCoin::new(1, 2, 3, 4);

--- a/tosho_musq/src/helper.rs
+++ b/tosho_musq/src/helper.rs
@@ -202,6 +202,7 @@ pub struct ConsumeCoin {
 }
 
 impl ConsumeCoin {
+    /// Create a new instance of coin consumption
     pub fn new(free: u64, event: u64, paid: u64, need: u64) -> Self {
         Self {
             free,

--- a/tosho_musq/src/helper.rs
+++ b/tosho_musq/src/helper.rs
@@ -13,7 +13,6 @@
 use std::str::FromStr;
 
 use chrono::Datelike;
-use serde::{Deserialize, Serialize};
 
 /// Weekly code for manga updates.
 ///

--- a/tosho_musq/src/lib.rs
+++ b/tosho_musq/src/lib.rs
@@ -1,3 +1,9 @@
+#![warn(
+    missing_docs,
+    clippy::empty_docs,
+    rustdoc::broken_intra_doc_links,
+    clippy::missing_docs_in_private_items
+)]
 #![doc = include_str!("../README.md")]
 
 pub mod constants;

--- a/tosho_musq/src/lib.rs
+++ b/tosho_musq/src/lib.rs
@@ -128,7 +128,7 @@ impl MUClient {
     /// * `chapter` - The chapter you want to check with.
     ///
     /// # Example
-    /// ```no_run
+    /// ```rust,no_run
     /// use tosho_musq::MUClient;
     ///
     /// #[tokio::main]

--- a/tosho_musq/src/lib.rs
+++ b/tosho_musq/src/lib.rs
@@ -134,11 +134,11 @@ impl MUClient {
     /// #[tokio::main]
     /// async fn main() {
     ///     let client = MUClient::new("1234", tosho_musq::constants::get_constants(1)).unwrap();
-    ///    
+    ///
     ///     let user_point = client.get_user_point().await.unwrap();
     ///     let manga = client.get_manga(240).await.unwrap();
-    ///     let first_ch = &manga.chapters[0];
-    ///    
+    ///     let first_ch = &manga.chapters()[0];
+    ///
     ///     let coins = client.calculate_coin(&user_point, first_ch);
     ///     assert!(coins.is_possible());
     /// }

--- a/tosho_musq/src/lib.rs
+++ b/tosho_musq/src/lib.rs
@@ -44,7 +44,7 @@ impl MUClient {
     /// # Parameters
     /// * `secret` - The secret key to use for the client.
     /// * `constants` - The constants to use for the client.
-    pub fn new(secret: &str, constants: &'static Constants) -> ToshoResult<Self> {
+    pub fn new(secret: impl Into<String>, constants: &'static Constants) -> ToshoResult<Self> {
         Self::make_client(secret, constants, None)
     }
 
@@ -59,7 +59,7 @@ impl MUClient {
     }
 
     fn make_client(
-        secret: &str,
+        secret: impl Into<String>,
         constants: &'static Constants,
         proxy: Option<reqwest::Proxy>,
     ) -> ToshoResult<Self> {
@@ -87,7 +87,7 @@ impl MUClient {
 
         Ok(Self {
             inner: client,
-            secret: secret.to_string(),
+            secret: secret.into(),
             constants,
         })
     }
@@ -322,9 +322,9 @@ impl MUClient {
     ///
     /// # Parameters
     /// * `query` - The query to search for.
-    pub async fn search(&self, query: &str) -> ToshoResult<MangaResults> {
+    pub async fn search(&self, query: impl Into<String>) -> ToshoResult<MangaResults> {
         let mut params: HashMap<String, String> = HashMap::new();
-        params.insert("word".to_string(), query.to_string());
+        params.insert("word".to_string(), query.into());
 
         self.build_params(&mut params);
 

--- a/tosho_musq/src/lib.rs
+++ b/tosho_musq/src/lib.rs
@@ -1,9 +1,4 @@
-#![warn(
-    missing_docs,
-    clippy::empty_docs,
-    rustdoc::broken_intra_doc_links,
-    clippy::missing_docs_in_private_items
-)]
+#![warn(missing_docs, clippy::empty_docs, rustdoc::broken_intra_doc_links)]
 #![doc = include_str!("../README.md")]
 
 pub mod constants;
@@ -39,8 +34,11 @@ use tosho_common::{
 /// ```
 #[derive(Debug)]
 pub struct MUClient {
+    /// The inner client
     inner: reqwest::Client,
+    /// Current secret used
     secret: String,
+    /// The constants used
     constants: &'static Constants,
 }
 
@@ -64,6 +62,7 @@ impl MUClient {
         Self::make_client(&self.secret, self.constants, Some(proxy))
     }
 
+    /// Internal function to make the new client
     fn make_client(
         secret: impl Into<String>,
         constants: &'static Constants,
@@ -106,6 +105,7 @@ impl MUClient {
         params.insert("lang".to_string(), "en".to_string());
     }
 
+    /// Create a custom cosume coin object.
     fn build_coin(
         &self,
         need_coin: u64,
@@ -218,6 +218,7 @@ impl MUClient {
         }
     }
 
+    /// Build and merge URL into a full API url
     fn build_url(&self, path: &str) -> String {
         if path.starts_with('/') {
             return format!("{}{}", &*BASE_API, path);
@@ -226,6 +227,7 @@ impl MUClient {
         format!("{}/{}", &*BASE_API, path)
     }
 
+    /// Create an empty params
     fn empty_params(&self) -> HashMap<String, String> {
         let mut params: HashMap<String, String> = HashMap::new();
 

--- a/tosho_musq/src/proto/account.rs
+++ b/tosho_musq/src/proto/account.rs
@@ -4,96 +4,100 @@
 
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+use tosho_macros::AutoGetter;
+
 use super::{SubscriptionStatus, UserPoint};
 
 /// The device connected to the account.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct AccountDevice {
     /// The device ID.
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// The device name.
     #[prost(string, tag = "2")]
-    pub name: ::prost::alloc::string::String,
+    name: ::prost::alloc::string::String,
     /// The device installation date in unix timestamp.
     #[prost(uint64, tag = "3")]
-    pub install_at: u64,
+    install_at: u64,
 }
 
 /// The account view response.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct AccountView {
     /// The list of devices that you have logged in.
     #[prost(message, repeated, tag = "1")]
-    pub devices: ::prost::alloc::vec::Vec<AccountDevice>,
+    devices: ::prost::alloc::vec::Vec<AccountDevice>,
     /// Whether or not you have registered your account.
     #[prost(bool, optional, tag = "2")]
-    pub registered: ::core::option::Option<bool>,
+    #[skip_field]
+    registered: ::core::option::Option<bool>,
     /// The login URL to connect your account.
     #[prost(string, tag = "3")]
-    pub login_url: ::prost::alloc::string::String,
+    login_url: ::prost::alloc::string::String,
 }
 
 /// The setting view response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct SettingView {
     /// The bridge tag name.
     #[prost(string, tag = "1")]
-    pub tag_name: ::prost::alloc::string::String,
+    tag_name: ::prost::alloc::string::String,
     /// The bridge keyword.
     #[prost(string, tag = "2")]
-    pub keyword: ::prost::alloc::string::String,
+    keyword: ::prost::alloc::string::String,
 }
 
 /// Your personalized profile page view response.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct MyPageView {
     /// The manga list that you bookmarked/favorited.
     #[prost(message, repeated, tag = "1")]
-    pub favorites: ::prost::alloc::vec::Vec<super::MangaResultNode>,
+    favorites: ::prost::alloc::vec::Vec<super::MangaResultNode>,
     /// The manga list that you read.
     #[prost(message, repeated, tag = "2")]
-    pub history: ::prost::alloc::vec::Vec<super::MangaResultNode>,
+    history: ::prost::alloc::vec::Vec<super::MangaResultNode>,
     /// The event point that we get from the registration(?).
     #[prost(uint64, tag = "3")]
-    pub register_event_point: u64,
+    register_event_point: u64,
 }
 
 /// The node of each banner on the home page.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct HomeBanner {
     /// The manga ID.
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// The manga thumbnail URL.
     #[prost(string, tag = "2")]
-    pub image_url: ::prost::alloc::string::String,
+    image_url: ::prost::alloc::string::String,
     /// The manga intent URL.
     #[prost(string, tag = "3")]
-    pub intent_url: ::prost::alloc::string::String,
+    intent_url: ::prost::alloc::string::String,
 }
 
 /// The currently featured manga on the home page.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct HomeFeatured {
     /// The manga ID.
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// The manga thumbnail URL.
     #[prost(string, tag = "2")]
-    pub image_url: ::prost::alloc::string::String,
+    image_url: ::prost::alloc::string::String,
     /// The manga video thumbnail URL.
     #[prost(string, optional, tag = "3")]
-    pub video_url: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    video_url: ::core::option::Option<::prost::alloc::string::String>,
     /// The manga short description.
     #[prost(string, tag = "4")]
-    pub short_description: ::prost::alloc::string::String,
+    short_description: ::prost::alloc::string::String,
     /// The manga intent URL.
     #[prost(string, tag = "5")]
-    pub intent_url: ::prost::alloc::string::String,
+    intent_url: ::prost::alloc::string::String,
     /// The manga title.
     #[prost(string, tag = "6")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
 }
 
 /// The personalized home page view response.
@@ -101,56 +105,57 @@ pub struct HomeFeatured {
 /// The following is the ``v2`` version of the response.
 ///
 /// There is no known ``v1`` version of the response.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct HomeViewV2 {
     /// The user point.
     #[prost(message, tag = "1")]
-    pub user_point: ::core::option::Option<UserPoint>,
+    #[copyable]
+    user_point: ::core::option::Option<UserPoint>,
     /// The top most banner list. (Big single carousel)
     #[prost(message, repeated, tag = "3")]
-    pub top_banners: ::prost::alloc::vec::Vec<HomeBanner>,
+    top_banners: ::prost::alloc::vec::Vec<HomeBanner>,
     /// The top most sub-banner list. (Smaller carousel)
     #[prost(message, repeated, tag = "4")]
-    pub top_sub_banners: ::prost::alloc::vec::Vec<HomeBanner>,
+    top_sub_banners: ::prost::alloc::vec::Vec<HomeBanner>,
     /// The tutorial banner list, if any.
     #[prost(message, optional, tag = "5")]
-    pub tutorial_banner: ::core::option::Option<HomeBanner>,
+    tutorial_banner: ::core::option::Option<HomeBanner>,
     /// The updated manga section name. (e.g. "Updated for You")
     #[prost(string, tag = "6")]
-    pub updated_section_name: ::prost::alloc::string::String,
+    updated_section_name: ::prost::alloc::string::String,
     /// The updated manga list.
     #[prost(message, repeated, tag = "7")]
-    pub updated_titles: ::prost::alloc::vec::Vec<super::MangaResultNode>,
+    updated_titles: ::prost::alloc::vec::Vec<super::MangaResultNode>,
     /// The tag/genre list.
     #[prost(message, repeated, tag = "8")]
-    pub tags: ::prost::alloc::vec::Vec<super::Tag>,
+    tags: ::prost::alloc::vec::Vec<super::Tag>,
     /// The currently featured manga.
     #[prost(message, optional, tag = "9")]
-    pub featured: ::core::option::Option<HomeFeatured>,
+    featured: ::core::option::Option<HomeFeatured>,
     /// The new manga section name. (e.g. "New Series")
     #[prost(string, tag = "10")]
-    pub new_section_name: ::prost::alloc::string::String,
+    new_section_name: ::prost::alloc::string::String,
     /// The new manga list.
     #[prost(message, repeated, tag = "11")]
-    pub new_titles: ::prost::alloc::vec::Vec<super::MangaResultNode>,
+    new_titles: ::prost::alloc::vec::Vec<super::MangaResultNode>,
     /// The popular/ranking manga section name. (e.g. "Ranking")
     #[prost(string, tag = "12")]
-    pub ranking_section_name: ::prost::alloc::string::String,
+    ranking_section_name: ::prost::alloc::string::String,
     /// The popular/ranking manga list.
     #[prost(message, repeated, tag = "13")]
-    pub rankings: ::prost::alloc::vec::Vec<super::MangaGroup>,
+    rankings: ::prost::alloc::vec::Vec<super::MangaGroup>,
     /// The ranking description.
     #[prost(string, tag = "14")]
-    pub ranking_description: ::prost::alloc::string::String,
+    ranking_description: ::prost::alloc::string::String,
     /// The recommended banner image URL.
     #[prost(string, tag = "15")]
-    pub recommended_banner_image_url: ::prost::alloc::string::String,
+    recommended_banner_image_url: ::prost::alloc::string::String,
 }
 
 /// The account subscription status
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct AccountSubscriptionStatus {
     /// The subscription status.
     #[prost(enumeration = "SubscriptionStatus", tag = "1")]
-    pub status: i32,
+    status: i32,
 }

--- a/tosho_musq/src/proto/chapter.rs
+++ b/tosho_musq/src/proto/chapter.rs
@@ -4,6 +4,8 @@
 
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+use tosho_macros::AutoGetter;
+
 use super::enums::{Badge, ConsumptionType, Status};
 
 /// Represents a single chapter.
@@ -11,45 +13,51 @@ use super::enums::{Badge, ConsumptionType, Status};
 /// The following is ``v1`` implementation of the chapter that used by the API.
 ///
 /// See also: [``ChapterV2``]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct Chapter {
     /// The chapter ID.
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// The chapter title.
     #[prost(string, tag = "2")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
     /// The chapter subtitle, usually the actual chapter title.
     #[prost(string, optional, tag = "3")]
-    pub subtitle: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    subtitle: ::core::option::Option<::prost::alloc::string::String>,
     /// The chapter thumbnail URL.
     #[prost(string, tag = "4")]
-    pub thumbnail_url: ::prost::alloc::string::String,
+    thumbnail_url: ::prost::alloc::string::String,
     /// The chapter consumption type.
     #[prost(enumeration = "ConsumptionType", tag = "5")]
-    pub consumption: i32,
+    #[skip_field]
+    consumption: i32,
     /// The chapter price in coins, check with [``Self::consumption``] to see which type of coins
     /// can be used to read this chapter.
     #[prost(uint64, tag = "6")]
-    pub price: u64,
+    price: u64,
     /// How much chapter rental period left in seconds.
     ///
     /// If the value is ``0``, the chapter rental period has ended.
     /// If the value is ``None``, the chapter is not yet rented.
     #[prost(uint64, optional, tag = "7")]
-    pub end_of_rental_period: ::core::option::Option<u64>,
+    #[skip_field]
+    end_of_rental_period: ::core::option::Option<u64>,
     /// How many comments this chapter has.
     #[prost(uint64, optional, tag = "8")]
-    pub comments: ::core::option::Option<u64>,
+    #[skip_field]
+    comments: ::core::option::Option<u64>,
     /// When this chapter was published.
     #[prost(string, optional, tag = "9")]
-    pub published_at: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    published_at: ::core::option::Option<::prost::alloc::string::String>,
     /// The chapter badge.
     #[prost(enumeration = "Badge", tag = "10")]
-    pub badge: i32,
+    #[skip_field]
+    badge: i32,
     /// The first page URL of this chapter.
     #[prost(string, tag = "11")]
-    pub first_page_url: ::prost::alloc::string::String,
+    first_page_url: ::prost::alloc::string::String,
 }
 
 impl Chapter {
@@ -119,6 +127,11 @@ impl Chapter {
             base_title
         }
     }
+
+    /// Set subtitle field, not recommended to use.
+    pub fn set_subtitle(&mut self, subtitle: impl Into<String>) {
+        self.subtitle = Some(subtitle.into())
+    }
 }
 
 /// Represents a single chapter.
@@ -126,54 +139,60 @@ impl Chapter {
 /// The following is ``v2`` implementation of the chapter that used by the API.
 ///
 /// See also: [``Chapter``]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct ChapterV2 {
     /// The chapter ID.
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// The chapter title.
     #[prost(string, tag = "2")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
     /// The chapter subtitle, usually the actual chapter title.
     #[prost(string, optional, tag = "3")]
-    pub subtitle: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    subtitle: ::core::option::Option<::prost::alloc::string::String>,
     /// The chapter thumbnail URL.
     #[prost(string, tag = "4")]
-    pub thumbnail_url: ::prost::alloc::string::String,
+    thumbnail_url: ::prost::alloc::string::String,
     /// The chapter consumption type.
     #[prost(enumeration = "ConsumptionType", tag = "5")]
-    pub consumption: i32,
+    #[skip_field]
+    consumption: i32,
     /// The chapter price in coins, check with [``Self::consumption``] to see which type of coins
     /// can be used to read this chapter.
     #[prost(uint64, tag = "6")]
-    pub price: u64,
+    price: u64,
     /// How much chapter rental period left in seconds.
     ///
     /// If the value is ``0``, the chapter rental period has ended.
     /// If the value is ``None``, the chapter is not yet rented.
     #[prost(uint64, optional, tag = "7")]
-    pub end_of_rental_period: ::core::option::Option<u64>,
+    #[skip_field]
+    end_of_rental_period: ::core::option::Option<u64>,
     /// How many comments this chapter has.
     #[prost(uint64, optional, tag = "8")]
-    pub comments: ::core::option::Option<u64>,
+    #[skip_field]
+    comments: ::core::option::Option<u64>,
     /// When this chapter was published.
     #[prost(string, optional, tag = "9")]
-    pub published_at: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    published_at: ::core::option::Option<::prost::alloc::string::String>,
     /// The chapter badge.
     #[prost(enumeration = "Badge", tag = "10")]
-    pub badge: i32,
+    #[skip_field]
+    badge: i32,
     /// The first page URL of this chapter.
     #[prost(string, tag = "11")]
-    pub first_page_url: ::prost::alloc::string::String,
+    first_page_url: ::prost::alloc::string::String,
     /// Whether this is the final chapter or not.
     #[prost(bool, tag = "12")]
-    pub final_chapter: bool,
+    final_chapter: bool,
     /// How many pages this chapter has.
     #[prost(uint64, tag = "13")]
-    pub page_count: u64,
+    page_count: u64,
     /// How many times this chapter has been read.
     #[prost(uint64, tag = "14")]
-    pub read_count: u64,
+    read_count: u64,
 }
 
 impl ChapterV2 {
@@ -249,6 +268,11 @@ impl ChapterV2 {
             base_title
         }
     }
+
+    /// Set subtitle field, not recommended to use.
+    pub fn set_subtitle(&mut self, subtitle: impl Into<String>) {
+        self.subtitle = Some(subtitle.into())
+    }
 }
 
 impl From<ChapterV2> for Chapter {
@@ -270,20 +294,23 @@ impl From<ChapterV2> for Chapter {
 }
 
 /// Represents a chapter page.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct ChapterPage {
     /// The page URL.
     #[prost(string, tag = "1")]
-    pub url: ::prost::alloc::string::String,
+    url: ::prost::alloc::string::String,
     /// The video HLS URL.
     #[prost(string, optional, tag = "2")]
-    pub video_url: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    video_url: ::core::option::Option<::prost::alloc::string::String>,
     /// The chapter page URL intents.
     #[prost(string, optional, tag = "3")]
-    pub intent_url: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    intent_url: ::core::option::Option<::prost::alloc::string::String>,
     /// The extra ID, if any.
     #[prost(uint64, optional, tag = "4")]
-    pub extra_id: ::core::option::Option<u64>,
+    #[skip_field]
+    extra_id: ::core::option::Option<u64>,
 }
 
 impl ChapterPage {
@@ -364,72 +391,81 @@ impl ChapterPage {
             file_name
         }
     }
+
+    /// Set the URL of the image
+    ///
+    /// This is mostly used for testing, so it's not recommended to be used.
+    pub fn set_url(&mut self, url: impl Into<String>) {
+        self.url = url.into();
+    }
 }
 
 /// Represents a chapter viewer response.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct ChapterViewer {
     /// The status of the request.
     #[prost(enumeration = "Status", tag = "1")]
-    pub status: i32,
+    #[skip_field]
+    status: i32,
     /// The user purse or point.
     #[prost(message, tag = "2")]
-    pub user_point: ::core::option::Option<super::UserPoint>,
+    #[copyable]
+    user_point: ::core::option::Option<super::UserPoint>,
     /// The chapter images list.
     #[prost(message, repeated, tag = "3")]
-    pub images: ::prost::alloc::vec::Vec<ChapterPage>,
+    images: ::prost::alloc::vec::Vec<ChapterPage>,
     /// The next chapter, if any.
     #[prost(message, optional, tag = "4")]
-    pub next_chapter: ::core::option::Option<Chapter>,
+    next_chapter: ::core::option::Option<Chapter>,
     /// The previous chapter, if any.
     #[prost(message, optional, tag = "5")]
-    pub previous_chapter: ::core::option::Option<Chapter>,
+    previous_chapter: ::core::option::Option<Chapter>,
     /// The chapter page start.
     #[prost(uint64, tag = "6")]
-    pub page_start: u64,
+    page_start: u64,
     /// Whether the chapter comment is enabled or not.
     #[prost(bool, tag = "8")]
-    pub is_comment_enabled: bool,
+    is_comment_enabled: bool,
 }
 
 /// Represents an SNS/Social Media sharing info.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct SNSInfo {
     /// The text body.
     #[prost(string, tag = "1")]
-    pub body: ::prost::alloc::string::String,
+    body: ::prost::alloc::string::String,
     /// The URL/intent url.
     #[prost(string, tag = "2")]
-    pub url: ::prost::alloc::string::String,
+    url: ::prost::alloc::string::String,
 }
 
 /// Represents a single page? block
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct PageBlock {
     /// The chapter ID.
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// The chapter title.
     #[prost(string, tag = "2")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
     /// The images list for the current block.
     #[prost(message, repeated, tag = "3")]
-    pub images: ::prost::alloc::vec::Vec<ChapterPage>,
+    images: ::prost::alloc::vec::Vec<ChapterPage>,
     /// Whether this is the last page or not.
     #[prost(bool, tag = "4")]
-    pub last_page: bool,
+    last_page: bool,
     /// The chapter page start.
     #[prost(uint64, tag = "5")]
-    pub start_page: u64,
+    start_page: u64,
     /// The chapter SNS.
     #[prost(message, tag = "6")]
-    pub sns: ::core::option::Option<SNSInfo>,
+    sns: ::core::option::Option<SNSInfo>,
     /// The chapter page start.
     #[prost(uint64, tag = "7")]
-    pub page_start: u64,
+    page_start: u64,
     /// The chapter page end.
     #[prost(uint64, tag = "8")]
-    pub page_end: u64,
+    page_end: u64,
 }
 
 /// Represents a chapter viewer response.
@@ -437,24 +473,26 @@ pub struct PageBlock {
 /// The following is ``v2`` implementation of the chapter viewer response that used by the API.
 ///
 /// See also: [``ChapterViewer``]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct ChapterViewerV2 {
     /// The status of the request.
     #[prost(enumeration = "Status", tag = "1")]
-    pub status: i32,
+    #[skip_field]
+    status: i32,
     /// The user purse or point.
     #[prost(message, tag = "2")]
-    pub user_point: ::core::option::Option<super::UserPoint>,
+    #[copyable]
+    user_point: ::core::option::Option<super::UserPoint>,
     /// The chapter images list.
     #[prost(message, repeated, tag = "3")]
-    pub blocks: ::prost::alloc::vec::Vec<PageBlock>,
+    blocks: ::prost::alloc::vec::Vec<PageBlock>,
     /// The next chapter, if any.
     #[prost(message, optional, tag = "4")]
-    pub next_chapter: ::core::option::Option<ChapterV2>,
+    next_chapter: ::core::option::Option<ChapterV2>,
     /// Whether the chapter comment is enabled or not.
     #[prost(bool, tag = "5")]
-    pub is_comment_enabled: bool,
+    is_comment_enabled: bool,
     /// Whether the chapter view guide is enabled or not.
     #[prost(bool, tag = "6")]
-    pub enable_guide: bool,
+    enable_guide: bool,
 }

--- a/tosho_musq/src/proto/chapter.rs
+++ b/tosho_musq/src/proto/chapter.rs
@@ -62,31 +62,6 @@ pub struct Chapter {
 
 impl Chapter {
     /// Whether or not this chapter is free.
-    ///
-    /// # Examples
-    /// ```
-    /// use tosho_musq::proto::Chapter;
-    ///
-    /// let mut chapter = Chapter {
-    ///     id: 1,
-    ///     title: "Test".to_string(),
-    ///     subtitle: Some("Subtitle".to_string()),
-    ///     thumbnail_url: "https://example.com".to_string(),
-    ///     consumption: 1,
-    ///     price: 0,
-    ///     end_of_rental_period: Some(0),
-    ///     comments: Some(0),
-    ///     published_at: Some("2021-01-01T00:00:00Z".to_string()),
-    ///     badge: 0,
-    ///     first_page_url: "https://example.com".to_string(),
-    /// };
-    ///
-    /// assert!(chapter.is_free());
-    ///
-    /// chapter.price = 10;
-    ///
-    /// assert!(!chapter.is_free());
-    /// ```
     pub fn is_free(&self) -> bool {
         self.price == 0
     }
@@ -94,31 +69,6 @@ impl Chapter {
     /// Format the chapter title and subtitle into a single string.
     ///
     /// If the subtitle is [`None`], the title will be returned as is.
-    ///
-    /// # Examples
-    /// ```
-    /// use tosho_musq::proto::Chapter;
-    ///
-    /// let mut chapter = Chapter {
-    ///     id: 1,
-    ///     title: "Test".to_string(),
-    ///     subtitle: Some("Subtitle".to_string()),
-    ///     thumbnail_url: "https://example.com".to_string(),
-    ///     consumption: 1,
-    ///     price: 0,
-    ///     end_of_rental_period: Some(0),
-    ///     comments: Some(0),
-    ///     published_at: Some("2021-01-01T00:00:00Z".to_string()),
-    ///     badge: 0,
-    ///     first_page_url: "https://example.com".to_string(),
-    /// };
-    ///
-    /// assert_eq!(chapter.as_chapter_title(), "Test — Subtitle");
-    ///
-    /// chapter.subtitle = None;
-    ///
-    /// assert_eq!(chapter.as_chapter_title(), "Test");
-    /// ```
     pub fn as_chapter_title(&self) -> String {
         let base_title = self.title.clone();
         if let Some(subtitle) = self.subtitle.clone() {
@@ -197,34 +147,6 @@ pub struct ChapterV2 {
 
 impl ChapterV2 {
     /// Whether or not this chapter is free.
-    ///
-    /// # Examples
-    /// ```
-    /// use tosho_musq::proto::ChapterV2;
-    ///
-    /// let mut chapter = ChapterV2 {
-    ///     id: 1,
-    ///     title: "Test".to_string(),
-    ///     subtitle: Some("Subtitle".to_string()),
-    ///     thumbnail_url: "https://example.com".to_string(),
-    ///     consumption: 1,
-    ///     price: 0,
-    ///     end_of_rental_period: Some(0),
-    ///     comments: Some(0),
-    ///     published_at: Some("2021-01-01T00:00:00Z".to_string()),
-    ///     badge: 0,
-    ///     first_page_url: "https://example.com".to_string(),
-    ///     final_chapter: false,
-    ///     page_count: 2,
-    ///     read_count: 0,
-    /// };
-    ///
-    /// assert!(chapter.is_free());
-    ///
-    /// chapter.price = 10;
-    ///
-    /// assert!(!chapter.is_free());
-    /// ```
     pub fn is_free(&self) -> bool {
         self.price == 0
     }
@@ -232,34 +154,6 @@ impl ChapterV2 {
     /// Format the chapter title and subtitle into a single string.
     ///
     /// If the subtitle is [`None`], the title will be returned as is.
-    ///
-    /// # Examples
-    /// ```
-    /// use tosho_musq::proto::ChapterV2;
-    ///
-    /// let mut chapter = ChapterV2 {
-    ///     id: 1,
-    ///     title: "Test".to_string(),
-    ///     subtitle: Some("Subtitle".to_string()),
-    ///     thumbnail_url: "https://example.com".to_string(),
-    ///     consumption: 1,
-    ///     price: 0,
-    ///     end_of_rental_period: Some(0),
-    ///     comments: Some(0),
-    ///     published_at: Some("2021-01-01T00:00:00Z".to_string()),
-    ///     badge: 0,
-    ///     first_page_url: "https://example.com".to_string(),
-    ///     final_chapter: false,
-    ///     page_count: 2,
-    ///     read_count: 0,
-    /// };
-    ///
-    /// assert_eq!(chapter.as_chapter_title(), "Test — Subtitle");
-    ///
-    /// chapter.subtitle = None;
-    ///
-    /// assert_eq!(chapter.as_chapter_title(), "Test");
-    /// ```
     pub fn as_chapter_title(&self) -> String {
         let base_title = self.title.clone();
         if let Some(subtitle) = self.subtitle.clone() {
@@ -316,19 +210,8 @@ pub struct ChapterPage {
 impl ChapterPage {
     /// The file name of the image.
     ///
-    /// # Examples
-    /// ```
-    /// use tosho_musq::proto::ChapterPage;
-    ///
-    /// let page = ChapterPage {
-    ///     url: "/path/to/image.avif".to_string(),
-    ///     video_url: None,
-    ///     intent_url: None,
-    ///     extra_id: None,
-    /// };
-    ///
-    /// assert_eq!(page.file_name(), "image.avif");
-    /// ```
+    /// When you have the URL of `/path/to/image.avif`, the filename
+    /// would become `image.avif` including the extension.
     pub fn file_name(&self) -> String {
         let url = self.url.clone();
         // split at the last slash
@@ -340,19 +223,9 @@ impl ChapterPage {
 
     /// The file extension of the image.
     ///
-    /// # Examples
-    /// ```
-    /// use tosho_musq::proto::ChapterPage;
-    ///
-    /// let page = ChapterPage {
-    ///     url: "/path/to/image.avif".to_string(),
-    ///     video_url: None,
-    ///     intent_url: None,
-    ///     extra_id: None,
-    /// };
-    ///
-    /// assert_eq!(page.extension(), "avif");
-    /// ```
+    /// When you have the URL of `/path/to/image.avif`,
+    /// the extension would become `avif`, when there
+    /// is no extension it would return an empty string.
     pub fn extension(&self) -> String {
         let file_name = self.file_name();
         // split at the last dot
@@ -367,19 +240,8 @@ impl ChapterPage {
 
     /// The file stem of the image.
     ///
-    /// # Examples
-    /// ```
-    /// use tosho_musq::proto::ChapterPage;
-    ///
-    /// let page = ChapterPage {
-    ///     url: "/path/to/image.avif".to_string(),
-    ///     video_url: None,
-    ///     intent_url: None,
-    ///     extra_id: None,
-    /// };
-    ///
-    /// assert_eq!(page.file_stem(), "image");
-    /// ```
+    /// When you have the URL of `/path/to/image.avif`,
+    /// the file stem would become `image`.
     pub fn file_stem(&self) -> String {
         let file_name = self.file_name();
         // split at the last dot

--- a/tosho_musq/src/proto/manga.rs
+++ b/tosho_musq/src/proto/manga.rs
@@ -2,63 +2,66 @@
 //!
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
+use tosho_macros::AutoGetter;
+
 use super::{
     AccountSubscriptionStatus, BadgeManga, LabelBadgeManga, Status, SubscriptionBadge, UserPoint,
 };
 
 /// The tag or genre information.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct Tag {
     /// The tag ID.
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// The tag name.
     #[prost(string, tag = "2")]
-    pub name: ::prost::alloc::string::String,
+    name: ::prost::alloc::string::String,
     /// The tag image URL.
     #[prost(string, optional, tag = "3")]
-    pub image_url: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    image_url: ::core::option::Option<::prost::alloc::string::String>,
 }
 
 /// The button that will be shown in the manga detail page
 /// that the user can interact with to view a chapter.
 ///
 /// This is made for the [`Chapter`](struct.Chapter.html) struct.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct ViewButton {
     /// The chapter that will be accessed if user click this button.
     #[prost(message, tag = "1")]
-    pub chapter: ::core::option::Option<super::Chapter>,
+    chapter: ::core::option::Option<super::Chapter>,
     /// The button text.
     #[prost(string, tag = "2")]
-    pub text: ::prost::alloc::string::String,
+    text: ::prost::alloc::string::String,
 }
 
 /// The button that will be shown in the manga detail page
 /// that the user can interact with to view a chapter.
 ///
 /// This is made for the [`ChapterV2`](struct.ChapterV2.html) struct.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct ViewButtonV2 {
     /// The chapter that will be accessed if user click this button.
     #[prost(message, tag = "1")]
-    pub chapter: ::core::option::Option<super::ChapterV2>,
+    chapter: ::core::option::Option<super::ChapterV2>,
     /// The button text.
     #[prost(string, tag = "2")]
-    pub text: ::prost::alloc::string::String,
+    text: ::prost::alloc::string::String,
 }
 
 /// A hidden chapters range.
 ///
 /// Made only for the [``MangaDetailV2``].
-#[derive(Clone, PartialEq, Copy, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, AutoGetter, ::prost::Message)]
 pub struct ChaptersRange {
     /// The start chapter ID.
     #[prost(uint64, tag = "1")]
-    pub start: u64,
+    start: u64,
     /// The end chapter ID.
     #[prost(uint64, tag = "2")]
-    pub end: u64,
+    end: u64,
 }
 
 /// A simplified manga information
@@ -68,59 +71,64 @@ pub struct ChaptersRange {
 /// This is the ``v1`` version of the manga detail response.
 ///
 /// See also: [``MangaDetailV2``]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct MangaDetail {
     /// The status of the requests.
     #[prost(enumeration = "Status", tag = "1")]
-    pub status: i32,
+    #[skip_field]
+    status: i32,
     /// The user point information.
     #[prost(message, tag = "2")]
-    pub user_point: ::core::option::Option<UserPoint>,
+    #[copyable]
+    user_point: ::core::option::Option<UserPoint>,
     /// The manga title.
     #[prost(string, tag = "3")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
     /// The manga authors, separated by comma.
     #[prost(string, tag = "4")]
-    pub authors: ::prost::alloc::string::String,
+    authors: ::prost::alloc::string::String,
     /// The manga copyright information.
     #[prost(string, tag = "5")]
-    pub copyright: ::prost::alloc::string::String,
+    copyright: ::prost::alloc::string::String,
     /// The next chapter update time in datetime format.
     #[prost(string, optional, tag = "6")]
-    pub next_update: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    next_update: ::core::option::Option<::prost::alloc::string::String>,
     /// The manga warning/sensitive information.
     #[prost(string, optional, tag = "7")]
-    pub warning: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    warning: ::core::option::Option<::prost::alloc::string::String>,
     /// The manga description.
     #[prost(string, tag = "8")]
-    pub description: ::prost::alloc::string::String,
+    description: ::prost::alloc::string::String,
     /// Whether the description is displayed or not.
     #[prost(bool, tag = "9")]
-    pub display_description: bool,
+    display_description: bool,
     /// The manga tags/genres.
     #[prost(message, repeated, tag = "10")]
-    pub tags: ::prost::alloc::vec::Vec<Tag>,
+    tags: ::prost::alloc::vec::Vec<Tag>,
     /// The manga thumbnail URL.
     #[prost(string, tag = "11")]
-    pub thumbnail_url: ::prost::alloc::string::String,
+    thumbnail_url: ::prost::alloc::string::String,
     /// The manga video thumbnail URL.
     #[prost(string, optional, tag = "12")]
-    pub video_url: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    video_url: ::core::option::Option<::prost::alloc::string::String>,
     /// The manga chapters.
     #[prost(message, repeated, tag = "13")]
-    pub chapters: ::prost::alloc::vec::Vec<super::Chapter>,
+    chapters: ::prost::alloc::vec::Vec<super::Chapter>,
     /// Whether the manga is favorited or not.
     #[prost(bool, tag = "14")]
-    pub is_favorite: bool,
+    is_favorite: bool,
     /// The view button, if any.
     #[prost(message, optional, tag = "15")]
-    pub view_button: ::core::option::Option<ViewButton>,
+    view_button: ::core::option::Option<ViewButton>,
     /// Whether the manga comments is enabled or not.
     #[prost(bool, tag = "16")]
-    pub is_comment_enabled: bool,
+    is_comment_enabled: bool,
     /// Related manga list.
     #[prost(message, repeated, tag = "17")]
-    pub related_manga: ::prost::alloc::vec::Vec<MangaResultNode>,
+    related_manga: ::prost::alloc::vec::Vec<MangaResultNode>,
 }
 
 /// Manga detail information responses.
@@ -128,126 +136,137 @@ pub struct MangaDetail {
 /// This is the ``v2`` version of the manga detail response.
 ///
 /// See also: [``MangaDetail``]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct MangaDetailV2 {
     /// The status of the requests.
     #[prost(enumeration = "Status", tag = "1")]
-    pub status: i32,
+    #[skip_field]
+    status: i32,
     /// The user point information.
     #[prost(message, tag = "2")]
-    pub user_point: ::core::option::Option<UserPoint>,
+    #[copyable]
+    user_point: ::core::option::Option<UserPoint>,
     /// The manga title.
     #[prost(string, tag = "3")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
     /// The manga authors, separated by comma.
     #[prost(string, tag = "4")]
-    pub authors: ::prost::alloc::string::String,
+    authors: ::prost::alloc::string::String,
     /// The manga copyright information.
     #[prost(string, tag = "5")]
-    pub copyright: ::prost::alloc::string::String,
+    copyright: ::prost::alloc::string::String,
     /// The next chapter update time in datetime format.
     #[prost(string, optional, tag = "6")]
-    pub next_update: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    next_update: ::core::option::Option<::prost::alloc::string::String>,
     /// The manga warning/sensitive information.
     #[prost(string, optional, tag = "7")]
-    pub warning: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    warning: ::core::option::Option<::prost::alloc::string::String>,
     /// The manga description.
     #[prost(string, tag = "8")]
-    pub description: ::prost::alloc::string::String,
+    description: ::prost::alloc::string::String,
     /// Whether the description is displayed or not.
     #[prost(bool, tag = "9")]
-    pub display_description: bool,
+    display_description: bool,
     /// The manga tags/genres.
     #[prost(message, repeated, tag = "10")]
-    pub tags: ::prost::alloc::vec::Vec<Tag>,
+    tags: ::prost::alloc::vec::Vec<Tag>,
     /// The manga thumbnail URL.
     #[prost(string, tag = "11")]
-    pub thumbnail_url: ::prost::alloc::string::String,
+    thumbnail_url: ::prost::alloc::string::String,
     /// The manga video thumbnail URL.
     #[prost(string, optional, tag = "12")]
-    pub video_url: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    video_url: ::core::option::Option<::prost::alloc::string::String>,
     /// The manga chapters.
     #[prost(message, repeated, tag = "13")]
-    pub chapters: ::prost::alloc::vec::Vec<super::ChapterV2>,
+    chapters: ::prost::alloc::vec::Vec<super::ChapterV2>,
     /// Whether the manga is favorited or not.
     #[prost(bool, tag = "14")]
-    pub is_favorite: bool,
+    is_favorite: bool,
     /// The view button, if any.
     #[prost(message, optional, tag = "15")]
-    pub view_button: ::core::option::Option<ViewButton>,
+    view_button: ::core::option::Option<ViewButton>,
     /// Whether the manga comments is enabled or not.
     #[prost(bool, tag = "16")]
-    pub is_comment_enabled: bool,
+    is_comment_enabled: bool,
     /// Related manga list.
     #[prost(message, repeated, tag = "17")]
-    pub related_manga: ::prost::alloc::vec::Vec<MangaResultNode>,
+    related_manga: ::prost::alloc::vec::Vec<MangaResultNode>,
     /// The hidden chapters range.
     #[prost(message, optional, tag = "18")]
-    pub hidden_chapters: ::core::option::Option<ChaptersRange>,
+    hidden_chapters: ::core::option::Option<ChaptersRange>,
     /// The subscription status of the user.
     #[prost(message, optional, tag = "19")]
-    pub subscription_status: ::core::option::Option<AccountSubscriptionStatus>,
+    subscription_status: ::core::option::Option<AccountSubscriptionStatus>,
 }
 
 /// A simplified manga information used in the search result.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct MangaResultNode {
     /// The manga ID.
     #[prost(uint64, tag = "1")]
-    pub id: u64,
+    id: u64,
     /// The manga title.
     #[prost(string, tag = "2")]
-    pub title: ::prost::alloc::string::String,
+    title: ::prost::alloc::string::String,
     /// The manga cover URL.
     #[prost(string, tag = "3")]
-    pub image_url: ::prost::alloc::string::String,
+    image_url: ::prost::alloc::string::String,
     /// The manga video thumbnail URL.
     #[prost(string, optional, tag = "4")]
-    pub video_url: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    video_url: ::core::option::Option<::prost::alloc::string::String>,
     /// The manga short description.
     #[prost(string, tag = "5")]
-    pub short_description: ::prost::alloc::string::String,
+    short_description: ::prost::alloc::string::String,
     /// The manga campaign information.
     #[prost(string, optional, tag = "6")]
-    pub campaign: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    campaign: ::core::option::Option<::prost::alloc::string::String>,
     /// The manga bookmark/favorites count.
     #[prost(uint64, tag = "7")]
-    pub favorites: u64,
+    favorites: u64,
     /// The manga badge information.
     #[prost(enumeration = "BadgeManga", tag = "8")]
-    pub badge: i32,
+    #[skip_field]
+    badge: i32,
     /// The manga last update date in datetime format.
     #[prost(string, optional, tag = "9")]
-    pub last_update: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    last_update: ::core::option::Option<::prost::alloc::string::String>,
     /// The label badge information.
     #[prost(enumeration = "LabelBadgeManga", tag = "10")]
-    pub label_badge: i32,
+    #[skip_field]
+    label_badge: i32,
     /// The subscription badge information.
     #[prost(enumeration = "SubscriptionBadge", tag = "11")]
-    pub subscription_badge: i32,
+    #[skip_field]
+    subscription_badge: i32,
 }
 
 /// The manga search result responses.
 ///
 /// Contains the manga list that match the search query,
 /// or used in the weekly updates information.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct MangaResults {
     /// The manga list.
     #[prost(message, repeated, tag = "1")]
-    pub titles: ::prost::alloc::vec::Vec<MangaResultNode>,
+    titles: ::prost::alloc::vec::Vec<MangaResultNode>,
 }
 
 /// A grouping of manga by tag/genres.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct MangaGroup {
     /// The tag/genre name.
     #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
+    name: ::prost::alloc::string::String,
     /// The associated manga list.
     #[prost(message, repeated, tag = "2")]
-    pub titles: ::prost::alloc::vec::Vec<MangaResultNode>,
+    titles: ::prost::alloc::vec::Vec<MangaResultNode>,
     /// The tag/genre ID.
     #[prost(uint64, tag = "3")]
-    pub tag_id: u64,
+    tag_id: u64,
 }

--- a/tosho_musq/src/proto/mod.rs
+++ b/tosho_musq/src/proto/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
+#![warn(clippy::missing_docs_in_private_items)]
+
 pub mod account;
 pub mod chapter;
 pub mod enums;

--- a/tosho_musq/src/proto/point.rs
+++ b/tosho_musq/src/proto/point.rs
@@ -4,22 +4,24 @@
 
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+use tosho_macros::AutoGetter;
+
 use super::{SubscriptionKind, SubscriptionStatus};
 
 /// The user point information.
 ///
 /// This will be available on almost each request.
-#[derive(Clone, PartialEq, Copy, ::prost::Message)]
+#[derive(Clone, PartialEq, Copy, AutoGetter, ::prost::Message)]
 pub struct UserPoint {
     /// Free/daily coins that you have.
     #[prost(uint64, tag = "1")]
-    pub free: u64,
+    free: u64,
     /// Event/XP coins that you have.
     #[prost(uint64, tag = "2")]
-    pub event: u64,
+    event: u64,
     /// Paid coins that you have.
     #[prost(uint64, tag = "3")]
-    pub paid: u64,
+    paid: u64,
 }
 
 impl UserPoint {
@@ -27,8 +29,8 @@ impl UserPoint {
     ///
     /// # Examples
     /// ```
-    /// use tosho_musq::proto::UserPoint;
-    ///
+    /// # use tosho_musq::proto::UserPoint;
+    /// #
     /// let points = UserPoint {
     ///    free: 100,
     ///    event: 200,
@@ -40,44 +42,94 @@ impl UserPoint {
     pub fn sum(&self) -> u64 {
         self.free + self.event + self.paid
     }
+
+    /// Subtract points from free slot
+    pub fn subtract_free(&mut self, amount: u64) {
+        self.free = self.free.saturating_sub(amount);
+    }
+
+    /// Subtract points from event slot
+    pub fn subtract_event(&mut self, amount: u64) {
+        self.event = self.event.saturating_sub(amount);
+    }
+
+    /// Subtract points from paid slot
+    pub fn subtract_paid(&mut self, amount: u64) {
+        self.paid = self.paid.saturating_sub(amount);
+    }
+
+    /// Add points to free slot
+    pub fn add_free(&mut self, amount: u64) {
+        self.free = self.free.saturating_add(amount);
+    }
+
+    /// Add points to event slot
+    pub fn add_event(&mut self, amount: u64) {
+        self.event = self.event.saturating_add(amount);
+    }
+
+    /// Add points to paid slot
+    pub fn add_paid(&mut self, amount: u64) {
+        self.paid = self.paid.saturating_add(amount);
+    }
+
+    /// Set points of free slot
+    pub fn set_free(&mut self, amount: u64) {
+        self.free = amount;
+    }
+
+    /// Set points of event slot
+    pub fn set_event(&mut self, amount: u64) {
+        self.event = amount;
+    }
+
+    /// Set points of paid slot
+    pub fn set_paid(&mut self, amount: u64) {
+        self.paid = amount;
+    }
 }
 
 /// The user subscription information.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct Subscription {
     /// The monthly subscription ID.
     #[prost(string, tag = "1")]
-    pub monthly_id: ::prost::alloc::string::String,
+    monthly_id: ::prost::alloc::string::String,
     /// The yearly subscription ID.
     #[prost(string, tag = "2")]
-    pub yearly_id: ::prost::alloc::string::String,
+    yearly_id: ::prost::alloc::string::String,
     /// The subscription kind of this subscription.
     #[prost(enumeration = "SubscriptionKind", tag = "3")]
-    pub status: i32,
+    #[skip_field]
+    status: i32,
     /// The unix timestamp of the end of the subscription.
     #[prost(int64, tag = "4")]
-    pub end: i64,
+    end: i64,
     /// The event point that we will get from the subscription.
     #[prost(uint64, tag = "5")]
-    pub event_point: u64,
+    event_point: u64,
     /// The subscription name.
     #[prost(string, tag = "6")]
-    pub name: ::prost::alloc::string::String,
+    name: ::prost::alloc::string::String,
     /// The seasonally (tri-annual) subscription ID.
     #[prost(string, optional, tag = "7")]
-    pub seasonally_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    seasonally_id: ::core::option::Option<::prost::alloc::string::String>,
     /// The half yearly subscription ID.
     #[prost(string, optional, tag = "8")]
-    pub half_yearly_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    half_yearly_id: ::core::option::Option<::prost::alloc::string::String>,
     /// The subscription banner URL.
     #[prost(string, optional, tag = "9")]
-    pub banner: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    banner: ::core::option::Option<::prost::alloc::string::String>,
     /// The subscription series URL scheme.
     #[prost(string, optional, tag = "10")]
-    pub series_url_scheme: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    series_url_scheme: ::core::option::Option<::prost::alloc::string::String>,
     /// The monthly subscription descriptions.
     #[prost(string, repeated, tag = "11")]
-    pub monthly_descriptions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    monthly_descriptions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 
 /// The billing or the coin purchase information.
@@ -121,62 +173,67 @@ impl Billing {
 /// Represents the point shop view responses.
 ///
 /// The ``Shop`` section in the actual app.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct PointShopView {
     /// The user purse or point.
     #[prost(message, tag = "1")]
-    pub user_point: ::core::option::Option<UserPoint>,
+    #[copyable]
+    user_point: ::core::option::Option<UserPoint>,
     /// The user point limit.
     #[prost(message, tag = "2")]
-    pub point_limit: ::core::option::Option<UserPoint>,
+    #[copyable]
+    point_limit: ::core::option::Option<UserPoint>,
     /// The next free point recovery time in seconds.
     #[prost(uint64, tag = "3")]
-    pub next_recovery: u64,
+    next_recovery: u64,
     /// The subscription list.
     #[prost(message, repeated, tag = "4")]
-    pub subscriptions: ::prost::alloc::vec::Vec<Subscription>,
+    subscriptions: ::prost::alloc::vec::Vec<Subscription>,
     /// The billing or purchase list.
     #[prost(message, repeated, tag = "5")]
-    pub billings: ::prost::alloc::vec::Vec<Billing>,
+    billings: ::prost::alloc::vec::Vec<Billing>,
     /// The default selected billing index(?).
     #[prost(uint64, tag = "6")]
-    pub default_select: u64,
+    default_select: u64,
     /// The user subscription status.
     #[prost(enumeration = "SubscriptionStatus", tag = "7")]
-    pub subscription_status: i32,
+    #[skip_field]
+    subscription_status: i32,
     /// The subscription terms and billing information.
     #[prost(string, optional, tag = "8")]
-    pub subscription_terms: ::core::option::Option<::prost::alloc::string::String>,
+    #[skip_field]
+    subscription_terms: ::core::option::Option<::prost::alloc::string::String>,
 }
 
 /// The node of each point purchase history.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct PointHistory {
     /// The displayed/title text.
     #[prost(string, tag = "1")]
-    pub displayed_text: ::prost::alloc::string::String,
+    displayed_text: ::prost::alloc::string::String,
     /// The free point that we use/get from the purchase.
     #[prost(uint64, tag = "2")]
-    pub free_point: u64,
+    free_point: u64,
     /// The event point that we use/get from the purchase.
     #[prost(uint64, tag = "3")]
-    pub event_point: u64,
+    event_point: u64,
     /// The paid point that we use/get from the purchase.
     #[prost(uint64, tag = "4")]
-    pub paid_point: u64,
+    paid_point: u64,
     /// The unix timestamp of the purchase/acquisition.
     #[prost(uint64, tag = "5")]
-    pub created_at: u64,
+    created_at: u64,
 }
 
 /// Represents the point history view responses.
 ///
 /// The ``Shop`` -> ``Acquisition History`` section in the actual app.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, AutoGetter, ::prost::Message)]
 pub struct PointHistoryView {
     /// The user purse or point.
     #[prost(message, tag = "1")]
-    pub user_point: ::core::option::Option<super::UserPoint>,
+    #[copyable]
+    pub user_point: ::core::option::Option<UserPoint>,
     /// The point history list.
     #[prost(message, repeated, tag = "2")]
     pub logs: ::prost::alloc::vec::Vec<PointHistory>,

--- a/tosho_musq/src/proto/point.rs
+++ b/tosho_musq/src/proto/point.rs
@@ -31,11 +31,10 @@ impl UserPoint {
     /// ```
     /// # use tosho_musq::proto::UserPoint;
     /// #
-    /// let points = UserPoint {
-    ///    free: 100,
-    ///    event: 200,
-    ///    paid: 300,
-    /// };
+    /// let mut points = UserPoint::default();
+    /// points.add_free(100);
+    /// points.add_event(200);
+    /// points.add_paid(300);
     ///
     /// assert_eq!(points.sum(), 600);
     /// ```

--- a/tosho_musq/tests/proto_test.rs
+++ b/tosho_musq/tests/proto_test.rs
@@ -85,23 +85,23 @@ fn test_proto_chapter_view() {
 
             let result = ChapterViewer::decode(proto_bytes.as_slice()).unwrap();
             assert_eq!(result.status(), Status::Success);
-            let user_point = result.user_point.unwrap();
-            assert_eq!(user_point.free, 0);
-            assert_eq!(user_point.event, 0);
-            assert_eq!(user_point.paid, 480);
+            let user_point = result.user_point().unwrap_or_default();
+            assert_eq!(user_point.free(), 0);
+            assert_eq!(user_point.event(), 0);
+            assert_eq!(user_point.paid(), 480);
             assert_eq!(user_point.sum(), 480);
 
-            assert!(result.previous_chapter.is_none());
-            assert!(result.next_chapter.is_some());
-            assert_eq!(result.images.len(), 11);
+            assert!(result.previous_chapter().is_none());
+            assert!(result.next_chapter().is_some());
+            assert_eq!(result.images().len(), 11);
 
-            let image = result.images.first().unwrap();
+            let image = result.images().first().unwrap();
             assert_eq!(image.file_name(), "1.avif");
             assert_eq!(image.file_stem(), "1");
             assert_eq!(image.extension(), "avif");
 
-            let mut image2 = result.images.get(1).unwrap().clone();
-            image2.url = "/data/1/noextension".to_owned();
+            let mut image2 = result.images().get(1).unwrap().clone();
+            image2.set_url("/data/1/noextension");
             assert_eq!(image2.file_name(), "noextension");
             assert_eq!(image2.file_stem(), "noextension");
             assert_eq!(image2.extension(), "");
@@ -122,24 +122,24 @@ fn test_proto_chapter_viewv2() {
 
             let result = ChapterViewerV2::decode(proto_bytes.as_slice()).unwrap();
             assert_eq!(result.status(), Status::Success);
-            let user_point = result.user_point.unwrap();
-            assert_eq!(user_point.free, 40);
-            assert_eq!(user_point.event, 0);
-            assert_eq!(user_point.paid, 370);
+            let user_point = result.user_point().unwrap();
+            assert_eq!(user_point.free(), 40);
+            assert_eq!(user_point.event(), 0);
+            assert_eq!(user_point.paid(), 370);
             assert_eq!(user_point.sum(), 410);
 
-            assert_eq!(result.blocks.len(), 1);
-            assert!(result.next_chapter.is_some());
+            assert_eq!(result.blocks().len(), 1);
+            assert!(result.next_chapter().is_some());
 
-            let block = result.blocks.first().unwrap();
-            assert_eq!(block.title, "Chapter 10.1");
-            let image = block.images.first().unwrap();
+            let block = result.blocks().first().unwrap();
+            assert_eq!(block.title(), "Chapter 10.1");
+            let image = block.images().first().unwrap();
             assert_eq!(image.file_name(), "1.avif");
             assert_eq!(image.file_stem(), "1");
             assert_eq!(image.extension(), "avif");
 
-            let mut image2 = block.images.get(1).unwrap().clone();
-            image2.url = "/data/1/noextension".to_owned();
+            let mut image2 = block.images().get(1).unwrap().clone();
+            image2.set_url("/data/1/noextension");
             assert_eq!(image2.file_name(), "noextension");
             assert_eq!(image2.file_stem(), "noextension");
             assert_eq!(image2.extension(), "");
@@ -160,9 +160,9 @@ fn test_proto_coinhistory() {
 
             let result = PointHistoryView::decode(proto_bytes.as_slice()).unwrap();
             let user_point = result.user_point.unwrap();
-            assert_eq!(user_point.free, 0);
-            assert_eq!(user_point.event, 0);
-            assert_eq!(user_point.paid, 280);
+            assert_eq!(user_point.free(), 0);
+            assert_eq!(user_point.event(), 0);
+            assert_eq!(user_point.paid(), 280);
             assert_eq!(user_point.sum(), 280);
 
             assert!(!result.logs.is_empty());
@@ -182,19 +182,19 @@ fn test_proto_homev2() {
             let proto_bytes = hex_to_bytes(&proto_hex);
 
             let result = HomeViewV2::decode(proto_bytes.as_slice()).unwrap();
-            assert!(!result.top_banners.is_empty());
-            assert!(!result.top_sub_banners.is_empty());
-            assert!(result.tutorial_banner.is_none());
-            assert_eq!(result.updated_section_name, "Updates for you");
-            assert!(!result.updated_titles.is_empty());
-            assert_eq!(result.tags.len(), 8);
-            assert!(result.featured.is_some());
-            assert_eq!(result.new_section_name, "New Series");
-            assert!(!result.new_titles.is_empty());
-            assert_eq!(result.ranking_section_name, "Ranking");
-            assert_eq!(result.rankings.len(), 4);
-            assert_ne!(result.ranking_description, "");
-            assert_ne!(result.recommended_banner_image_url, "");
+            assert!(!result.top_banners().is_empty());
+            assert!(!result.top_sub_banners().is_empty());
+            assert!(result.tutorial_banner().is_none());
+            assert_eq!(result.updated_section_name(), "Updates for you");
+            assert!(!result.updated_titles().is_empty());
+            assert_eq!(result.tags().len(), 8);
+            assert!(result.featured().is_some());
+            assert_eq!(result.new_section_name(), "New Series");
+            assert!(!result.new_titles().is_empty());
+            assert_eq!(result.ranking_section_name(), "Ranking");
+            assert_eq!(result.rankings().len(), 4);
+            assert_ne!(result.ranking_description(), "");
+            assert_ne!(result.recommended_banner_image_url(), "");
         }
     }
 }
@@ -214,31 +214,31 @@ fn test_proto_mangadetail() {
             assert_eq!(result.status(), Status::Success);
 
             assert_eq!(
-                result.title,
+                result.title(),
                 "The Diary of a Middle-Aged Teacher's Carefree Life in Another World"
             );
             assert_eq!(
-                result.authors,
+                result.authors(),
                 "Kotobuki Yasukiyo, Maneki, Ryu Nishin, Johndee"
             );
-            assert!(!result.copyright.is_empty());
+            assert!(!result.copyright().is_empty());
 
-            assert!(result.next_update.is_none());
-            assert!(result.warning.is_none());
-            assert!(!result.description.is_empty());
-            assert!(!result.display_description);
-            assert_eq!(result.tags.len(), 1);
-            assert!(result.video_url.is_none());
+            assert!(result.next_update().is_empty());
+            assert!(result.warning().is_empty());
+            assert!(!result.description().is_empty());
+            assert!(!result.display_description());
+            assert_eq!(result.tags().len(), 1);
+            assert!(result.video_url().is_empty());
 
-            assert!(!result.chapters.is_empty());
+            assert!(!result.chapters().is_empty());
 
-            let first_ch = result.chapters.last().unwrap();
-            let mut last_ch = result.chapters.first().unwrap().clone();
-            assert_eq!(first_ch.title, "Chapter 1.1");
-            assert_eq!(last_ch.title, "Chapter 44.2");
+            let first_ch = result.chapters().last().unwrap();
+            let mut last_ch = result.chapters().first().unwrap().clone();
+            assert_eq!(first_ch.title(), "Chapter 1.1");
+            assert_eq!(last_ch.title(), "Chapter 44.2");
             assert!(first_ch.is_free());
             assert!(!last_ch.is_free());
-            last_ch.subtitle = Some("Test".to_owned());
+            last_ch.set_subtitle("Test");
             assert_eq!(first_ch.as_chapter_title(), "Chapter 1.1");
             assert_eq!(last_ch.as_chapter_title(), "Chapter 44.2 — Test");
         }
@@ -259,30 +259,33 @@ fn test_proto_mangadetailv2() {
             let result = MangaDetailV2::decode(proto_bytes.as_slice()).unwrap();
             assert_eq!(result.status(), Status::Success);
 
-            assert_eq!(result.title, "The Angel Next Door Spoils Me Rotten");
-            assert_eq!(result.authors, "Saekisan, Hanekoto, Wan Shibata, Suzu Yuki");
-            assert!(!result.copyright.is_empty());
+            assert_eq!(result.title(), "The Angel Next Door Spoils Me Rotten");
+            assert_eq!(
+                result.authors(),
+                "Saekisan, Hanekoto, Wan Shibata, Suzu Yuki"
+            );
+            assert!(!result.copyright().is_empty());
 
-            assert!(result.next_update.is_none());
-            assert!(result.warning.is_none());
-            assert!(!result.description.is_empty());
-            assert!(!result.display_description);
-            assert_eq!(result.tags.len(), 3);
-            assert!(result.video_url.is_none());
+            assert!(result.next_update().is_empty());
+            assert!(result.warning().is_empty());
+            assert!(!result.description().is_empty());
+            assert!(!result.display_description());
+            assert_eq!(result.tags().len(), 3);
+            assert!(result.video_url().is_empty());
 
-            assert!(!result.chapters.is_empty());
+            assert!(!result.chapters().is_empty());
 
-            let first_ch = result.chapters.last().unwrap();
-            let mut last_ch = result.chapters.first().unwrap().clone();
-            assert_eq!(first_ch.title, "Chapter 1.1");
-            assert_eq!(last_ch.title, "Chapter 10.3");
+            let first_ch = result.chapters().last().unwrap();
+            let mut last_ch = result.chapters().first().unwrap().clone();
+            assert_eq!(first_ch.title(), "Chapter 1.1");
+            assert_eq!(last_ch.title(), "Chapter 10.3");
             assert!(first_ch.is_free());
             assert!(last_ch.is_free());
-            last_ch.subtitle = Some("Test".to_owned());
+            last_ch.set_subtitle("Test");
             assert_eq!(first_ch.as_chapter_title(), "Chapter 1.1");
             assert_eq!(last_ch.as_chapter_title(), "Chapter 10.3 — Test");
 
-            assert!(result.hidden_chapters.is_none());
+            assert!(result.hidden_chapters().is_none());
         }
     }
 }
@@ -299,8 +302,8 @@ fn test_proto_mypage() {
             let proto_bytes = hex_to_bytes(&proto_hex);
 
             let result = MyPageView::decode(proto_bytes.as_slice()).unwrap();
-            assert!(!result.favorites.is_empty());
-            assert!(!result.history.is_empty());
+            assert!(!result.favorites().is_empty());
+            assert!(!result.history().is_empty());
         }
     }
 }
@@ -317,22 +320,22 @@ fn test_proto_pointshopview() {
             let proto_bytes = hex_to_bytes(&proto_hex);
 
             let result = PointShopView::decode(proto_bytes.as_slice()).unwrap();
-            let user_point = result.user_point.unwrap();
-            assert_eq!(user_point.free, 0);
-            assert_eq!(user_point.event, 0);
-            assert_eq!(user_point.paid, 480);
+            let user_point = result.user_point().unwrap();
+            assert_eq!(user_point.free(), 0);
+            assert_eq!(user_point.event(), 0);
+            assert_eq!(user_point.paid(), 480);
 
-            let point_limit = result.point_limit.unwrap();
-            assert_eq!(point_limit.free, 40);
-            assert_eq!(point_limit.event, 100000);
-            assert_eq!(point_limit.paid, 100000);
+            let point_limit = result.point_limit().unwrap();
+            assert_eq!(point_limit.free(), 40);
+            assert_eq!(point_limit.event(), 100000);
+            assert_eq!(point_limit.paid(), 100000);
 
-            assert_eq!(result.next_recovery, 1674604800);
-            assert_eq!(result.subscriptions.len(), 0);
-            assert_eq!(result.billings.len(), 9);
-            assert_eq!(result.default_select, 0);
+            assert_eq!(result.next_recovery(), 1674604800);
+            assert_eq!(result.subscriptions().len(), 0);
+            assert_eq!(result.billings().len(), 9);
+            assert_eq!(result.default_select(), 0);
 
-            let billing = result.billings.get(8).unwrap();
+            let billing = result.billings().get(8).unwrap();
             assert_eq!(billing.event_point, 8040);
             assert_eq!(billing.paid_point, 26800);
             assert_eq!(billing.total_point(), 34840);

--- a/tosho_rbean/README.md
+++ b/tosho_rbean/README.md
@@ -15,11 +15,7 @@ use tosho_rbean::{RBClient, RBConfig, RBPlatform};
 
 #[tokio::main]
 async fn main() {
-    let config = RBConfig {
-        token: "123".to_string(),
-        refresh_token: "abcxyz".to_string(),
-        platform: RBPlatform::Android,
-    };
+    let config = RBConfig::new("123", "abcxyz", RBPlatform::Android);
     let mut client = RBClient::new(config).unwrap();
     // Refresh token
     client.refresh_token().await.unwrap();

--- a/tosho_rbean/src/config.rs
+++ b/tosho_rbean/src/config.rs
@@ -10,6 +10,8 @@
 //! };
 //! ```
 
+use tosho_macros::AutoGetter;
+
 use crate::models::accounts::google::{IdentityToolkitVerifyPasswordResponse, SecureTokenResponse};
 
 /// Represents the platform for the client.
@@ -31,17 +33,41 @@ pub enum RBPlatform {
 }
 
 /// Represents the configuration for the client.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, AutoGetter)]
 pub struct RBConfig {
     /// The token of the account
-    pub token: String,
+    token: String,
     /// The refresh token of the account
-    pub refresh_token: String,
+    refresh_token: String,
     /// The platform of the account
-    pub platform: RBPlatform,
+    #[copyable]
+    platform: RBPlatform,
 }
 
 impl RBConfig {
+    /// Create a new custom instance for [`RBConfig`]
+    pub fn new(
+        token: impl Into<String>,
+        refresh_token: impl Into<String>,
+        platform: RBPlatform,
+    ) -> Self {
+        Self {
+            token: token.into(),
+            refresh_token: refresh_token.into(),
+            platform,
+        }
+    }
+
+    /// Set a new token
+    pub fn set_token(&mut self, token: impl Into<String>) {
+        self.token = token.into();
+    }
+
+    /// Set a new refresh token
+    pub fn set_refresh_token(&mut self, refresh_token: impl Into<String>) {
+        self.refresh_token = refresh_token.into();
+    }
+
     /// Convert [`SecureTokenResponse`] to [`RBConfig`].
     pub fn from_secure_token(value: &SecureTokenResponse, platform: RBPlatform) -> Self {
         RBConfig {

--- a/tosho_rbean/src/config.rs
+++ b/tosho_rbean/src/config.rs
@@ -45,8 +45,8 @@ impl RBConfig {
     /// Convert [`SecureTokenResponse`] to [`RBConfig`].
     pub fn from_secure_token(value: &SecureTokenResponse, platform: RBPlatform) -> Self {
         RBConfig {
-            token: value.access_token.clone(),
-            refresh_token: value.refresh_token.clone(),
+            token: value.access_token().to_string(),
+            refresh_token: value.refresh_token().to_string(),
             platform,
         }
     }
@@ -57,8 +57,8 @@ impl RBConfig {
         platform: RBPlatform,
     ) -> Self {
         RBConfig {
-            token: value.id_token.clone(),
-            refresh_token: value.refresh_token.clone(),
+            token: value.id_token().to_string(),
+            refresh_token: value.refresh_token().to_string(),
             platform,
         }
     }

--- a/tosho_rbean/src/config.rs
+++ b/tosho_rbean/src/config.rs
@@ -14,7 +14,7 @@ use crate::models::accounts::google::{IdentityToolkitVerifyPasswordResponse, Sec
 
 /// Represents the platform for the client.
 ///
-/// ```
+/// ```rust
 /// use tosho_rbean::RBPlatform;
 ///
 /// let platform = RBPlatform::Android;

--- a/tosho_rbean/src/config.rs
+++ b/tosho_rbean/src/config.rs
@@ -3,11 +3,7 @@
 //! ```rust
 //! use tosho_rbean::{RBConfig, RBPlatform};
 //!
-//! let config = RBConfig {
-//!     token: "123".to_string(),
-//!     refresh_token: "abcxyz".to_string(),
-//!     platform: RBPlatform::Android,
-//! };
+//! let config = RBConfig::new("123", "abcxyz", RBPlatform::Android);
 //! ```
 
 use tosho_macros::AutoGetter;

--- a/tosho_rbean/src/constants.rs
+++ b/tosho_rbean/src/constants.rs
@@ -118,9 +118,9 @@ pub(crate) static X_DRM_HEADER: LazyLock<String> = LazyLock::new(|| {
 /// Panics if the device type is invalid.
 ///
 /// # Examples
-/// ```
-/// use tosho_rbean::constants::get_constants;
-///
+/// ```rust
+/// # use tosho_rbean::constants::get_constants;
+/// #
 /// let _ = get_constants(1); // Android
 /// ```
 pub fn get_constants(device_type: u8) -> &'static Constants {

--- a/tosho_rbean/src/lib.rs
+++ b/tosho_rbean/src/lib.rs
@@ -1,9 +1,4 @@
-#![warn(
-    missing_docs,
-    clippy::empty_docs,
-    rustdoc::broken_intra_doc_links,
-    clippy::missing_docs_in_private_items
-)]
+#![warn(missing_docs, clippy::empty_docs, rustdoc::broken_intra_doc_links)]
 #![doc = include_str!("../README.md")]
 
 use futures_util::TryStreamExt;
@@ -73,6 +68,7 @@ impl RBClient {
         Self::make_client(self.config.clone(), Some(proxy))
     }
 
+    /// Internal function to make the client
     fn make_client(config: RBConfig, proxy: Option<reqwest::Proxy>) -> ToshoResult<Self> {
         let constants = crate::constants::get_constants(config.platform() as u8);
         let mut headers = reqwest::header::HeaderMap::new();
@@ -188,6 +184,7 @@ impl RBClient {
 
     // <-- Common Helper
 
+    /// Request to the API with the given method and url.
     async fn request<T>(
         &mut self,
         method: reqwest::Method,

--- a/tosho_rbean/src/lib.rs
+++ b/tosho_rbean/src/lib.rs
@@ -1,3 +1,9 @@
+#![warn(
+    missing_docs,
+    clippy::empty_docs,
+    rustdoc::broken_intra_doc_links,
+    clippy::missing_docs_in_private_items
+)]
 #![doc = include_str!("../README.md")]
 
 use futures_util::TryStreamExt;
@@ -117,6 +123,9 @@ impl RBClient {
         })
     }
 
+    /// Set the expiry at of the token manually
+    ///
+    /// Not really recommended to use.
     pub fn set_expiry_at(&mut self, expiry_at: Option<i64>) {
         self.expiry_at = expiry_at;
     }

--- a/tosho_rbean/src/models/accounts.rs
+++ b/tosho_rbean/src/models/accounts.rs
@@ -39,6 +39,8 @@ pub struct ReadingListItem {
 
 /// Google related identity toolkit models
 pub mod google {
+    #![allow(clippy::missing_docs_in_private_items)]
+
     use serde::{Deserialize, Serialize};
     use tosho_macros::AutoGetter;
 

--- a/tosho_rbean/src/models/accounts.rs
+++ b/tosho_rbean/src/models/accounts.rs
@@ -3,107 +3,109 @@
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
 use serde::{Deserialize, Serialize};
+use tosho_macros::AutoGetter;
 
 use super::{Image, Label, MangaNode};
 
 /// User account information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct UserAccount {
     /// The UUID of the user.
-    pub uuid: String,
+    uuid: String,
     /// The username or handle of the user.
     #[serde(rename = "handle")]
-    pub username: Option<String>,
+    username: Option<String>,
     /// The email address of the user.
     #[serde(rename = "email_address")]
-    pub email: String,
+    email: String,
     /// The image or avatar of the user.
-    pub image: Option<Image>,
+    image: Option<Image>,
     /// Does the account has premium?
-    pub is_premium: bool,
+    is_premium: bool,
     /// The date when the premium expires.
     ///
     /// If [`None`] then the account does not have premium.
-    pub premium_expiration_date: Option<String>,
+    premium_expiration_date: Option<String>,
 }
 
 /// User reading list history
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ReadingListItem {
     /// The manga being read.
-    pub manga: MangaNode,
+    manga: MangaNode,
     /// The specific chapter being read.
-    pub chapter: Option<Label>,
+    chapter: Option<Label>,
 }
 
 pub mod google {
     use serde::{Deserialize, Serialize};
+    use tosho_macros::AutoGetter;
 
     /// Object representing the response of the verification of user entered password.
-    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
     pub struct IdentityToolkitVerifyPasswordResponse {
-        pub kind: String,
+        kind: String,
         #[serde(rename = "localId")]
-        pub local_id: String,
-        pub email: String,
+        local_id: String,
+        email: String,
         #[serde(rename = "displayName")]
-        pub display_name: String,
+        display_name: String,
         #[serde(rename = "idToken")]
-        pub id_token: String,
+        id_token: String,
         #[serde(rename = "registered")]
-        pub registered: bool,
+        registered: bool,
         #[serde(rename = "refreshToken")]
-        pub refresh_token: String,
+        refresh_token: String,
         #[serde(rename = "expiresIn")]
-        pub expires_in: String,
+        expires_in: String,
     }
 
     /// Object of each provider's information.
-    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
     pub struct IdentityToolkitAccountProviderInfo {
         #[serde(rename = "providerId")]
-        pub provider_id: String,
+        provider_id: String,
         #[serde(rename = "federatedId")]
-        pub federated_id: String,
-        pub email: String,
+        federated_id: String,
+        email: String,
     }
 
     /// Object of each user's information from single token.
-    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
     pub struct IdentityToolkitAccountInfo {
         #[serde(rename = "localId")]
-        pub local_id: String,
-        pub email: String,
+        local_id: String,
+        email: String,
         #[serde(rename = "passwordHash")]
-        pub password_hash: String,
+        password_hash: String,
         #[serde(rename = "emailVerified")]
-        pub email_verified: bool,
+        email_verified: bool,
         #[serde(rename = "validSince")]
-        pub valid_since: String,
+        valid_since: String,
         #[serde(rename = "lastLoginAt")]
-        pub last_login_at: String,
+        last_login_at: String,
         #[serde(rename = "createdAt")]
-        pub created_at: String,
+        created_at: String,
         #[serde(rename = "providerUserInfo")]
-        pub provider_user_info: Vec<IdentityToolkitAccountProviderInfo>,
+        provider_user_info: Vec<IdentityToolkitAccountProviderInfo>,
     }
 
     /// Object representing the response of the registered user's information.
-    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
     pub struct IdentityToolkitAccountInfoResponse {
-        pub kind: String,
-        pub users: Vec<IdentityToolkitAccountInfo>,
+        kind: String,
+        users: Vec<IdentityToolkitAccountInfo>,
     }
 
     /// Object representing the response of the token exchange.
-    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
     pub struct SecureTokenResponse {
-        pub access_token: String,
-        pub expires_in: String,
-        pub token_type: String,
-        pub refresh_token: String,
-        pub id_token: String,
-        pub user_id: String,
-        pub project_id: String,
+        access_token: String,
+        expires_in: String,
+        token_type: String,
+        refresh_token: String,
+        id_token: String,
+        user_id: String,
+        project_id: String,
     }
 }

--- a/tosho_rbean/src/models/accounts.rs
+++ b/tosho_rbean/src/models/accounts.rs
@@ -37,6 +37,7 @@ pub struct ReadingListItem {
     chapter: Option<Label>,
 }
 
+/// Google related identity toolkit models
 pub mod google {
     use serde::{Deserialize, Serialize};
     use tosho_macros::AutoGetter;

--- a/tosho_rbean/src/models/chapters.rs
+++ b/tosho_rbean/src/models/chapters.rs
@@ -5,107 +5,87 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use tosho_macros::AutoGetter;
 
 use super::{MangaNode, Volume};
 
 /// A minimal model for chapter information.
 ///
 /// Commonly used in [`crate::models::Carousel`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ChapterListNode {
     /// The UUID of the chapter.
-    pub uuid: String,
+    uuid: String,
     /// The chapter number/label.
     #[serde(rename = "label")]
-    pub chapter: String,
+    chapter: String,
     /// Is this a new chapter?
     #[serde(rename = "is_new")]
-    pub new: bool,
+    new: bool,
     /// Is this an upcoming chapter?
     #[serde(rename = "is_upcoming")]
-    pub upcoming: bool,
+    upcoming: bool,
     /// Is this a premium chapter?
     #[serde(rename = "is_premium")]
-    pub premium: bool,
+    premium: bool,
 }
 
 /// A struct containing information about a chapter.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct Chapter {
     /// The UUID of the chapter.
-    pub uuid: String,
+    uuid: String,
     /// The chapter number/label.
     #[serde(rename = "label")]
-    pub chapter: String,
+    chapter: String,
     /// The title of the chapter.
-    pub title: Option<String>,
+    title: Option<String>,
     /// The release date of the chapter.
     #[serde(
         rename = "release_date",
         serialize_with = "super::datetime::serialize_opt",
         deserialize_with = "super::datetime::deserialize_opt"
     )]
-    pub published: Option<chrono::DateTime<chrono::FixedOffset>>,
+    #[copyable]
+    published: Option<chrono::DateTime<chrono::FixedOffset>>,
     /// The free release date of the chapter.
     #[serde(
         rename = "free_release_date",
         serialize_with = "super::datetime::serialize_opt",
         deserialize_with = "super::datetime::deserialize_opt"
     )]
-    pub free_published: Option<chrono::DateTime<chrono::FixedOffset>>,
+    #[copyable]
+    free_published: Option<chrono::DateTime<chrono::FixedOffset>>,
     /// The original published date of the chapter.
     #[serde(
         rename = "original_published_date",
         serialize_with = "super::datetime::serialize_opt",
         deserialize_with = "super::datetime::deserialize_opt"
     )]
-    pub original_published: Option<chrono::DateTime<chrono::FixedOffset>>,
+    original_published: Option<chrono::DateTime<chrono::FixedOffset>>,
     /// Is this a new chapter?
     #[serde(rename = "is_new")]
-    pub new: bool,
+    new: bool,
     /// Is this an upcoming chapter?
     #[serde(rename = "is_upcoming")]
-    pub upcoming: bool,
+    upcoming: bool,
     /// Is this a premium chapter?
     #[serde(rename = "is_premium")]
-    pub premium: bool,
+    premium: bool,
     /// Last updated date of the chapter.
     #[serde(
         rename = "last_updated_at",
         serialize_with = "super::datetime::serialize_opt",
         deserialize_with = "super::datetime::deserialize_opt"
     )]
-    pub last_updated: Option<chrono::DateTime<chrono::FixedOffset>>,
+    #[copyable]
+    last_updated: Option<chrono::DateTime<chrono::FixedOffset>>,
     /// Volume UUID of the chapter.
-    pub volume_uuid: Option<String>,
+    volume_uuid: Option<String>,
 }
 
 impl Chapter {
     /// Get a formatted chapter number with the title.
-    ///
-    /// ```rust
-    /// use tosho_rbean::models::Chapter;
-    ///
-    /// let mut chapter = Chapter {
-    ///     uuid: "uuid".to_string(),
-    ///     chapter: "1".to_string(),
-    ///     title: Some("".to_string()),
-    ///     published: None,
-    ///     free_published: None,
-    ///     original_published: None,
-    ///     new: false,
-    ///     upcoming: false,
-    ///     premium: false,
-    ///     last_updated: None,
-    ///     volume_uuid: None,
-    /// };
-    ///
-    /// assert_eq!(chapter.formatted_title(), "Chapter 1");
-    ///
-    /// chapter.title = Some("Test Title".to_string());
-    ///
-    /// assert_eq!(chapter.formatted_title(), "Chapter 1 - Test Title");
-    /// ```
     pub fn formatted_title(&self) -> String {
         let title = self.title.as_deref().unwrap_or("");
         if title.is_empty() {
@@ -117,29 +97,29 @@ impl Chapter {
 }
 
 /// A chapter detail response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ChapterDetailsResponse {
     /// The chapter information.
-    pub chapter: Chapter,
+    chapter: Chapter,
     /// The manga information.
-    pub manga: MangaNode,
+    manga: MangaNode,
 }
 
 /// A chapter list response for a manga.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ChapterListResponse {
     /// The chapters of the manga.
-    pub chapters: Vec<Chapter>,
+    chapters: Vec<Chapter>,
     /// The volume mapping of the chapters.
     ///
     /// This map the `volume_uuid` to the [`Volume`] information.
     #[serde(rename = "volume_uuid_to_volume")]
-    pub volumes: HashMap<String, Volume>,
+    volumes: HashMap<String, Volume>,
     /// The separators of the chapters.
-    pub separators: Vec<super::common::Separator>,
+    separators: Vec<super::common::Separator>,
     /// The volume UUID sort order
     #[serde(rename = "volume_uuid_order")]
-    pub volume_order: Vec<String>,
+    volume_order: Vec<String>,
 }
 
 /// A single spread of a chapter.
@@ -148,44 +128,44 @@ pub struct ChapterListResponse {
 pub type Spread = (Option<i32>, Option<i32>);
 
 /// A struct containing a single page information of a chapter.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ChapterPage {
     /// The UUID of the page.
-    pub uuid: String,
+    uuid: String,
     /// The image of the page.
-    pub image: super::Image,
+    image: super::Image,
     /// The watermarked image of the page.
     #[serde(rename = "image_wm")]
-    pub watermarked_image: super::Image,
+    watermarked_image: super::Image,
     /// Is double page?
     #[serde(rename = "is_double_page")]
-    pub double_page: bool,
+    double_page: bool,
     /// The index of the spread info.
     ///
     /// This is a tuple value of `(left, right)` from [`ChapterPageDetails`].
     #[serde(rename = "spread_index")]
-    pub spread: i32,
+    spread: i32,
     /// The side of the page in the spread.
     ///
     /// Either `left` or `right`, you should realize that you need to reverse the side order if
     /// using right-to-left reading mode.
-    pub side: String,
+    side: String,
 }
 
 /// A struct containing information about a chapter pages.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ChapterPageDetails {
     /// Spreads information mapping.
-    pub spreads: Vec<Spread>,
+    spreads: Vec<Spread>,
     /// The pages of the chapter.
-    pub pages: Vec<ChapterPage>,
+    pages: Vec<ChapterPage>,
 }
 
 /// A response for chapter pages.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ChapterPageDetailsResponse {
     /// The pages information.
-    pub data: ChapterPageDetails,
+    data: ChapterPageDetails,
 }
 
 #[cfg(test)]

--- a/tosho_rbean/src/models/common.rs
+++ b/tosho_rbean/src/models/common.rs
@@ -110,6 +110,7 @@ pub struct ChapterGap {
 /// A chapter explainer, commonly used in separator.
 #[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize, PartialEq)]
 pub struct ChapterExplainer {
+    /// The number of chapters specified on the separator.
     #[serde(rename = "num_chapters")]
     count: i32,
 }

--- a/tosho_rbean/src/models/common.rs
+++ b/tosho_rbean/src/models/common.rs
@@ -3,134 +3,135 @@
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
 use serde::{Deserialize, Serialize};
+use tosho_macros::AutoGetter;
 
 use super::Image;
 
 /// Creator or author of a manga.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct Creator {
     /// The name of the creator.
-    pub name: String,
+    name: String,
     /// The UUID of the creator.
-    pub uuid: String,
+    uuid: String,
 }
 
 /// Publisher of a manga.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct Publisher {
     /// The name of the publisher.
-    pub name: String,
+    name: String,
     /// The UUID of the publisher.
-    pub uuid: String,
+    uuid: String,
     /// The URL slug of the publisher.
-    pub slug: String,
+    slug: String,
 }
 
 /// A label of a manga with UUID.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct Label {
     /// The name of the label.
     #[serde(rename = "label")]
-    pub name: String,
+    name: String,
     /// The UUID of the label.
-    pub uuid: String,
+    uuid: String,
 }
 
 /// A sort options filters for searching.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct SortOptions {
     /// The sort type.
-    pub r#type: String,
+    r#type: String,
     /// The sort name.
-    pub name: String,
+    name: String,
 }
 
 /// Tags available for searching.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct Tag {
     /// The name of the tag.
-    pub name: String,
+    name: String,
     /// The slug of the tag.
-    pub slug: String,
+    slug: String,
 }
 
 /// Genres available from [`crate::models::HomeResponse`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct HomeGenre {
     /// The name of the genre.
-    pub name: String,
+    name: String,
     /// The tag of the genre.
-    pub tag: String,
+    tag: String,
 }
 
 /// A collection of manga filters.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MangaFilters {
     /// The sort options.
-    pub sort_options: Vec<SortOptions>,
+    sort_options: Vec<SortOptions>,
     /// The available tags.
-    pub tags: Vec<Tag>,
+    tags: Vec<Tag>,
     /// The available options that can be toggled.
-    pub bool_options: Vec<String>,
+    bool_options: Vec<String>,
     /// The available publishers that can be used.
-    pub publishers: Vec<Publisher>,
+    publishers: Vec<Publisher>,
 }
 
 /// A manga product.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct Product {
     /// The UUID of the product.
-    pub uuid: String,
+    uuid: String,
     /// The type of the item
     #[serde(rename = "item_type")]
-    pub r#type: String,
+    r#type: String,
     /// The retail price of the product.
-    pub retail_price: String,
+    retail_price: String,
     /// The sale price of the product.
-    pub sale_price: String,
+    sale_price: String,
 }
 
 /// A chapter range.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize, PartialEq)]
 pub struct ChapterRange {
     /// The start of the chapter range.
-    pub start: String,
+    start: String,
     /// The end of the chapter range.
-    pub end: String,
+    end: String,
 }
 
 /// A chapter gap.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize, PartialEq)]
 pub struct ChapterGap {
     /// The range of the gap.
-    pub range: ChapterRange,
+    range: ChapterRange,
 }
 
 /// A chapter explainer, commonly used in separator.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize, PartialEq)]
 pub struct ChapterExplainer {
     #[serde(rename = "num_chapters")]
-    pub count: i32,
+    count: i32,
 }
 
 /// A separator for some common chapter explainer.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize, PartialEq)]
 pub struct SeparatorChapterExplainer {
     /// The index of the separator.
     #[serde(rename = "list_index")]
-    pub index: i32,
+    index: i32,
     /// The data of the separator.
-    pub data: ChapterExplainer,
+    data: ChapterExplainer,
 }
 
 /// A separator for chapter gap.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize, PartialEq)]
 pub struct SeparatorChapterGap {
     /// The index of the separator.
     #[serde(rename = "list_index")]
-    pub index: i32,
+    index: i32,
     /// The data of the separator.
-    pub data: ChapterGap,
+    data: ChapterGap,
 }
 
 /// A separator for chapters.
@@ -152,36 +153,36 @@ pub enum Separator {
 }
 
 /// A volume release product.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct Volume {
     /// The UUID of the volume.
-    pub uuid: String,
+    uuid: String,
     /// The manga UUID of the volume.
     #[serde(rename = "manga_uuid")]
-    pub manga: String,
+    manga: String,
     /// The ISBN of the volume.
-    pub isbn: Option<String>,
+    isbn: Option<String>,
     /// The cover image of the volume.
     #[serde(rename = "image")]
-    pub cover: Image,
+    cover: Image,
     /// The title of the volume.
     #[serde(rename = "full_name")]
-    pub title: String,
+    title: String,
     /// The short title of the volume.
     #[serde(rename = "short_name")]
-    pub short_title: String,
+    short_title: String,
     /// The volume number of the volume.
     #[serde(rename = "label")]
-    pub volume: String,
+    volume: String,
     /// Is DRM free
     #[serde(rename = "is_drm_free")]
-    pub drm_free: bool,
+    drm_free: bool,
     /// The retail/product info of the volume.
     #[serde(rename = "product", default)]
-    pub retail: Option<Product>,
+    retail: Option<Product>,
     /// The order of the volume.
     #[serde(rename = "order_number")]
-    pub order: i32,
+    order: i32,
 }
 
 #[cfg(test)]

--- a/tosho_rbean/src/models/datetime.rs
+++ b/tosho_rbean/src/models/datetime.rs
@@ -1,6 +1,9 @@
+//! Serde related helper for datetime format in RB
+
 use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Deserializer, Serializer};
 
+/// Serialize [`DateTime`] into a RFC3339 string that the API use.
 pub fn serialize<S>(date: &DateTime<FixedOffset>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -9,6 +12,7 @@ where
     serializer.serialize_str(&s)
 }
 
+/// Deserialize a RFC3339 string into [`DateTime`].
 pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<FixedOffset>, D::Error>
 where
     D: Deserializer<'de>,
@@ -18,6 +22,7 @@ where
     Ok(datetime)
 }
 
+/// Serialize an optional [`DateTime`] into a RFC3339 string that the API use.
 pub fn serialize_opt<S>(
     date: &Option<DateTime<FixedOffset>>,
     serializer: S,
@@ -34,6 +39,7 @@ where
     }
 }
 
+/// Deserialize an optional RFC3339 string into [`DateTime`].
 pub fn deserialize_opt<'de, D>(deserializer: D) -> Result<Option<DateTime<FixedOffset>>, D::Error>
 where
     D: Deserializer<'de>,

--- a/tosho_rbean/src/models/enums.rs
+++ b/tosho_rbean/src/models/enums.rs
@@ -1,7 +1,7 @@
 //! A module containing information related to enums used in the library.
 
 /// Sorting options for searching.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SortOption {
     /// Sort by alphabetical order.
     Alphabetical,

--- a/tosho_rbean/src/models/image.rs
+++ b/tosho_rbean/src/models/image.rs
@@ -5,33 +5,24 @@
 use std::cmp::Ordering;
 
 use serde::{Deserialize, Serialize};
+use tosho_macros::AutoGetter;
 
 /// A struct containing each image source.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ImageSource {
     /// The URL of the image.
-    pub url: String,
+    url: String,
     /// The width of the image.
-    pub width: i32,
+    width: i32,
     /// The height of the image.
-    pub height: i32,
+    height: i32,
 }
 
 impl ImageSource {
     /// The file name of the image.
     ///
-    /// # Examples
-    /// ```
-    /// use tosho_rbean::models::ImageSource;
-    ///
-    /// let page = ImageSource {
-    ///     width: 800,
-    ///     height: 1200,
-    ///     url: "https://example.com/image.jpg?ignore=me".to_string(),
-    /// };
-    ///
-    /// assert_eq!(page.file_name(), "image.jpg");
-    /// ```
+    /// When you have the URL of `https://example.com/image.jpg?ignore=me`,
+    /// the filename would become `image.jpg` including the extension.
     pub fn file_name(&self) -> String {
         let url = self.url.as_str();
         match url.rfind('/') {
@@ -48,18 +39,9 @@ impl ImageSource {
 
     /// The file extension of the image.
     ///
-    /// # Examples
-    /// ```
-    /// use tosho_rbean::models::ImageSource;
-    ///
-    /// let page = ImageSource {
-    ///     width: 800,
-    ///     height: 1200,
-    ///     url: "https://example.com/image.jpg?ignore=me".to_string(),
-    /// };
-    ///
-    /// assert_eq!(page.extension(), "jpg");
-    /// ```
+    /// When you have the URL of `https://example.com/image.jpg?ignore=me`,
+    /// the extension would become `jpg`, when there is no extension it
+    /// would return an empty string.
     pub fn extension(&self) -> String {
         let file_name = self.file_name();
         let split: Vec<&str> = file_name.rsplitn(2, '.').collect();
@@ -73,18 +55,8 @@ impl ImageSource {
 
     /// The file stem of the image.
     ///
-    /// # Examples
-    /// ```
-    /// use tosho_rbean::models::ImageSource;
-    ///
-    /// let page = ImageSource {
-    ///     width: 800,
-    ///     height: 1200,
-    ///     url: "https://example.com/image.jpg?ignore=me".to_string(),
-    /// };
-    ///
-    /// assert_eq!(page.file_stem(), "image");
-    /// ```
+    /// When you have the URL of `https://example.com/image.jpg?ignore=me`,
+    /// the file stem would become `image`.
     pub fn file_stem(&self) -> String {
         let file_name = self.file_name();
         let split: Vec<&str> = file_name.rsplitn(2, '.').collect();
@@ -132,12 +104,12 @@ impl Ord for ImageSource {
 }
 
 /// A struct containing collection of images.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct Image {
     /// WEBP images.
-    pub webp: Vec<ImageSource>,
+    webp: Vec<ImageSource>,
     /// JPEG images.
-    pub jpg: Vec<ImageSource>,
+    jpg: Vec<ImageSource>,
 }
 
 #[cfg(test)]

--- a/tosho_rbean/src/models/manga.rs
+++ b/tosho_rbean/src/models/manga.rs
@@ -3,248 +3,251 @@
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
 use serde::{Deserialize, Serialize};
+use tosho_macros::AutoGetter;
 
 use super::{Chapter, ChapterListNode, Creator, HomeGenre, Image, Publisher, Tag};
 
 /// Reading modes available for a manga.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize, Default)]
 pub struct ReadingModes {
     /// Is the manga available in single page mode?
     #[serde(rename = "single")]
-    pub single_page: bool,
+    single_page: bool,
     /// Is the manga available in double page mode?
     #[serde(rename = "spread")]
-    pub double_page: bool,
+    double_page: bool,
     /// Is the manga available in vertical mode?
-    pub vertical: bool,
+    vertical: bool,
 }
 
 /// Alternative titles of a manga.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct AlternativeTitles {
     /// The alternative title of the manga.
     #[serde(rename = "name")]
-    pub title: String,
+    title: String,
     /// The language of the alternative title.
-    pub locale: String,
+    locale: String,
     /// The order of the alternative title.
     #[serde(rename = "order_number")]
-    pub order: i32,
+    order: i32,
     /// Is the alternative title will be promoted/shown in the UI?
     #[serde(rename = "is_promoted")]
-    pub promoted: bool,
+    promoted: bool,
 }
 
 /// A struct containing information about a manga.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct Manga {
     /// The UUID of the manga.
-    pub uuid: String,
+    uuid: String,
     /// The title of the manga.
     #[serde(rename = "name")]
-    pub title: String,
+    title: String,
     /// The URL slug of the manga.
-    pub slug: String,
+    slug: String,
     /// The description of the manga.
     #[serde(rename = "short_description")]
-    pub description: String,
+    description: String,
     /// The cover image of the manga.
     #[serde(rename = "image")]
-    pub cover: Image,
+    cover: Image,
     /// The tags of the manga.
-    pub tags: Vec<String>,
+    tags: Vec<String>,
     /// Publisher of the manga.
-    pub publisher: Publisher,
+    publisher: Publisher,
     /// Creator/authors of the manga.
-    pub creators: Vec<Creator>,
+    creators: Vec<Creator>,
     /// Translation credits or publication credits
     #[serde(default)]
-    pub credits: Option<String>,
+    credits: Option<String>,
     /// Release schedule of the manga.
     #[serde(default)]
-    pub release_schedule: Option<String>,
+    release_schedule: Option<String>,
     /// Genres of the manga.
-    pub genres: Vec<Tag>,
+    genres: Vec<Tag>,
     /// Reading modes available for the manga.
     #[serde(default)]
-    pub reading_modes: ReadingModes,
+    reading_modes: ReadingModes,
     /// Alternative titles of the manga.
     #[serde(rename = "alt_titles", default)]
-    pub alternative_titles: Vec<AlternativeTitles>,
+    alternative_titles: Vec<AlternativeTitles>,
     /// Total available chapters
     #[serde(rename = "total_available_chapters")]
-    pub chapters: u32,
+    chapters: u32,
     /// Total available chapters that can be purchased (ala carte)
     #[serde(rename = "alc_available_chapters")]
-    pub purchaseables: u32,
+    purchaseables: u32,
     /// Total premium available chapters
     #[serde(rename = "premium_available_chapters")]
-    pub premium_chapters: u32,
+    premium_chapters: u32,
     /// Total free available chapters
     #[serde(rename = "free_available_chapters")]
-    pub free_chapters: u32,
+    free_chapters: u32,
     /// Is pass eligible?
     #[serde(rename = "is_pass_eligible")]
-    pub pass_eligible: bool,
+    pass_eligible: bool,
     /// Total available passes
     #[serde(rename = "total_passes")]
-    pub passes: Option<i32>,
+    passes: Option<i32>,
     /// Pass recharge in hours
     #[serde(rename = "pass_recharge_hours")]
-    pub pass_recharge: Option<i32>,
+    pass_recharge: Option<i32>,
     /// How long can the chapters be read with the pass
     #[serde(rename = "pass_unlock_hours")]
-    pub pass_unlock: Option<i32>,
+    pass_unlock: Option<i32>,
     /// Is the manga read from left to right?
-    pub is_ltr: bool,
+    is_ltr: bool,
     /// Last updated date of the manga.
     #[serde(rename = "last_updated_at", with = "super::datetime")]
-    pub last_updated: chrono::DateTime<chrono::FixedOffset>,
+    #[copyable]
+    last_updated: chrono::DateTime<chrono::FixedOffset>,
     /// Amazon affiliate link
     #[serde(default)]
-    pub amazon_affiliate: Option<String>,
+    amazon_affiliate: Option<String>,
 }
 
 /// A minimal version of [`Manga`] struct.
 ///
 /// Commonly used in search result and reading list.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MangaNode {
     /// The UUID of the manga.
-    pub uuid: String,
+    uuid: String,
     /// The title of the manga.
     #[serde(rename = "name")]
-    pub title: String,
+    title: String,
     /// The URL slug of the manga.
-    pub slug: String,
+    slug: String,
     /// The description of the manga.
     #[serde(rename = "short_description")]
-    pub description: String,
+    description: String,
     /// The cover image of the manga.
     #[serde(rename = "image")]
-    pub cover: Image,
+    cover: Image,
     /// The tags of the manga.
-    pub tags: Vec<String>,
+    tags: Vec<String>,
     /// Publisher UUID of the manga.
-    pub publisher_uuid: String,
+    publisher_uuid: String,
     /// Total available chapters
     #[serde(rename = "total_available_chapters")]
-    pub chapters: u32,
+    chapters: u32,
     /// Total available chapters that can be purchased (ala carte)
     #[serde(rename = "alc_available_chapters")]
-    pub purchaseables: u32,
+    purchaseables: u32,
     /// Total premium available chapters
     #[serde(rename = "premium_available_chapters")]
-    pub premium_chapters: u32,
+    premium_chapters: u32,
     /// Total free available chapters
     #[serde(rename = "free_available_chapters")]
-    pub free_chapters: u32,
+    free_chapters: u32,
     /// Is pass eligible?
     #[serde(rename = "is_pass_eligible")]
-    pub pass_eligible: bool,
+    pass_eligible: bool,
     /// Total available passes
     #[serde(rename = "total_passes")]
-    pub passes: Option<i32>,
+    passes: Option<i32>,
     /// Pass recharge in hours
     #[serde(rename = "pass_recharge_hours")]
-    pub pass_recharge: Option<i32>,
+    pass_recharge: Option<i32>,
     /// How long can the chapters be read with the pass
     #[serde(rename = "pass_unlock_hours")]
-    pub pass_unlock: Option<i32>,
+    pass_unlock: Option<i32>,
     /// Is the manga read from left to right?
-    pub is_ltr: bool,
+    is_ltr: bool,
     /// Last updated date of the manga.
     #[serde(rename = "last_updated_at", with = "super::datetime")]
-    pub last_updated: chrono::DateTime<chrono::FixedOffset>,
+    #[copyable]
+    last_updated: chrono::DateTime<chrono::FixedOffset>,
     /// Amazon affiliate link
     #[serde(default)]
-    pub amazon_affiliate: Option<String>,
+    amazon_affiliate: Option<String>,
     /// Latest available chapters
     #[serde(default)]
-    pub latest_chapters: Option<Vec<ChapterListNode>>,
+    latest_chapters: Option<Vec<ChapterListNode>>,
 }
 
 /// A struct containing search results of a manga.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MangaListResponse {
     /// The total count of the search result.
     #[serde(rename = "total_count")]
-    pub total: String,
+    total: String,
     /// The search results of the manga.
     #[serde(rename = "mangas")]
-    pub results: Vec<MangaNode>,
+    results: Vec<MangaNode>,
 }
 
 /// A struct containing information about hero banner
 ///
 /// Used in [`HomeResponse`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct HeroBanner {
     /// The banner title
-    pub title: String,
+    title: String,
     /// The banner subtitle
-    pub subtitle: String,
+    subtitle: String,
     /// The banner alt text
-    pub alt_text: String,
+    alt_text: String,
     /// The banner/cover image
-    pub image: String,
+    image: String,
     /// The background image of the manga cover
-    pub background: Image,
+    background: Image,
     /// The link to the manga
-    pub link: Option<String>,
+    link: Option<String>,
     /// The manga info, if [`None`] there is no featured manga
-    pub manga: Option<MangaNode>,
+    manga: Option<MangaNode>,
 }
 
 /// A struct containing information about the featured manga/chapter
 ///
 /// Used in [`HomeResponse`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct FeaturedManga {
     /// The feature label/title
     #[serde(rename = "label")]
-    pub title: String,
+    title: String,
     /// The description of the featured manga
-    pub description: String,
+    description: String,
     /// The manga info
-    pub manga: MangaNode,
+    manga: MangaNode,
 }
 
 /// A node for the carousel continue reading items
 ///
 /// Used in [`HomeResponse`] at [`CarouselContinueReading`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct CarouselContinueReadingNode {
     /// The manga info
-    pub manga: MangaNode,
+    manga: MangaNode,
     /// The chapter info
-    pub chapter: Chapter,
+    chapter: Chapter,
 }
 
 /// A struct containing information about continue reading carousel
 ///
 /// Used in [`HomeResponse`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct CarouselContinueReading {
     /// The carousel title
     #[serde(rename = "label")]
-    pub title: String,
+    title: String,
     /// The carousel items
     #[serde(rename = "mangas")]
-    pub items: Vec<CarouselContinueReadingNode>,
+    items: Vec<CarouselContinueReadingNode>,
 }
 
 /// A struct containing information about common carousels
 ///
 /// Used in [`HomeResponse`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct CarouselCommon {
     /// The carousel title
     #[serde(rename = "label")]
-    pub title: String,
+    title: String,
     /// The carousel items
     #[serde(rename = "mangas")]
-    pub items: Vec<MangaNode>,
+    items: Vec<MangaNode>,
 }
 
 /// A struct containing information about carousels in the home page
@@ -265,14 +268,14 @@ pub enum Carousel {
 }
 
 /// A struct containing information about the home page response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct HomeResponse {
     /// The hero banner
-    pub hero: HeroBanner,
+    hero: HeroBanner,
     /// The featured manga
-    pub featured: Vec<FeaturedManga>,
+    featured: Vec<FeaturedManga>,
     /// The carousel items
-    pub carousels: Vec<Carousel>,
+    carousels: Vec<Carousel>,
     /// The genres available
-    pub genres: Vec<HomeGenre>,
+    genres: Vec<HomeGenre>,
 }

--- a/tosho_rbean/src/models/mod.rs
+++ b/tosho_rbean/src/models/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
+#![warn(clippy::missing_docs_in_private_items)]
+
 pub mod accounts;
 pub mod chapters;
 pub mod common;

--- a/tosho_sjv/README.md
+++ b/tosho_sjv/README.md
@@ -15,13 +15,7 @@ use tosho_sjv::{SJClient, SJConfig, SJMode, SJPlatform};
 
 #[tokio::main]
 async fn main() {
-    let config = SJConfig {
-        user_id: 123,
-        token: "xyz987abc".to_string(),
-        instance: "abcxyz".to_string(),
-        platform: SJPlatform::Android,
-    };
-
+    let config = SJConfig::new(123, "xyz987abc", "abcxyz", SJPlatform::Android);
     let client = SJClient::new(config, SJMode::VM).unwrap();
     let manga = client.get_manga(vec![777]).await.unwrap();
     println!("{:?}", manga);

--- a/tosho_sjv/src/config.rs
+++ b/tosho_sjv/src/config.rs
@@ -3,13 +3,10 @@
 //! ```rust
 //! use tosho_sjv::{SJConfig, SJPlatform};
 //!
-//! let config = SJConfig {
-//!     user_id: 123,
-//!     token: "xyz987abc".to_string(),
-//!     instance: "abcxyz".to_string(),
-//!     platform: SJPlatform::Android,
-//! };
+//! let config = SJConfig::new(123, "xyz987abc", "abcxyz", SJPlatform::Android);
 //! ```
+
+use tosho_macros::AutoGetter;
 
 use crate::models::AccountLoginResponse;
 
@@ -54,23 +51,19 @@ pub enum SJPlatform {
 /// ```rust
 /// use tosho_sjv::{SJConfig, SJPlatform};
 ///
-/// let config = SJConfig {
-///     user_id: 123,
-///     token: "xyz987abc".to_string(),
-///     instance: "abcxyz".to_string(),
-///     platform: SJPlatform::Android,
-/// };
+/// let config = SJConfig::new(123, "xyz987abc", "abcxyz", SJPlatform::Android);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, AutoGetter)]
 pub struct SJConfig {
     /// User ID.
-    pub user_id: u32,
+    user_id: u32,
     /// Token or also known as trust_user_jwt
-    pub token: String,
+    token: String,
     /// Instance ID or device token
-    pub instance: String,
+    instance: String,
     /// Platform to use.
-    pub platform: SJPlatform,
+    #[copyable]
+    platform: SJPlatform,
 }
 
 impl SJConfig {
@@ -82,11 +75,16 @@ impl SJConfig {
     /// * `token` - The token.
     /// * `instance` - The instance.
     /// * `platform` - The platform.
-    pub fn new(user_id: u32, token: String, instance: String, platform: SJPlatform) -> Self {
+    pub fn new(
+        user_id: u32,
+        token: impl Into<String>,
+        instance: impl Into<String>,
+        platform: SJPlatform,
+    ) -> Self {
         Self {
             user_id,
-            token,
-            instance,
+            token: token.into(),
+            instance: instance.into(),
             platform,
         }
     }

--- a/tosho_sjv/src/config.rs
+++ b/tosho_sjv/src/config.rs
@@ -17,7 +17,7 @@ use crate::models::AccountLoginResponse;
 ///
 /// Since the original has two separate application.
 ///
-/// ```
+/// ```rust
 /// use tosho_sjv::SJMode;
 ///
 /// let mode = SJMode::SJ;
@@ -33,7 +33,7 @@ pub enum SJMode {
 
 /// The platform to use.
 ///
-/// ```
+/// ```rust
 /// use tosho_sjv::SJPlatform;
 ///
 /// let platform = SJPlatform::Android;
@@ -51,7 +51,7 @@ pub enum SJPlatform {
 
 /// The configuration for the client.
 ///
-/// ```
+/// ```rust
 /// use tosho_sjv::{SJConfig, SJPlatform};
 ///
 /// let config = SJConfig {
@@ -97,7 +97,7 @@ impl SJConfig {
     /// * `response` - The login response.
     /// * `instance` - The instance ID.
     ///
-    /// ```no_run
+    /// ```rust,no_run
     /// use tosho_sjv::{SJClient, SJConfig, SJMode, SJPlatform};
     ///
     /// #[tokio::main]

--- a/tosho_sjv/src/config.rs
+++ b/tosho_sjv/src/config.rs
@@ -118,8 +118,8 @@ impl SJConfig {
         platform: SJPlatform,
     ) -> Self {
         Self {
-            user_id: response.id,
-            token: response.token.clone(),
+            user_id: response.id(),
+            token: response.token().to_string(),
             instance,
             platform,
         }

--- a/tosho_sjv/src/constants.rs
+++ b/tosho_sjv/src/constants.rs
@@ -203,9 +203,9 @@ pub static EXPAND_SJ_NAME: LazyLock<String> = LazyLock::new(|| {
 /// Panics if the device type is invalid.
 ///
 /// # Examples
-/// ```
-/// use tosho_sjv::constants::get_constants;
-///
+/// ```rust
+/// # use tosho_sjv::constants::get_constants;
+/// #
 /// let _ = get_constants(1); // Android
 /// ```
 pub fn get_constants(device_type: u8) -> &'static Constants {

--- a/tosho_sjv/src/imaging.rs
+++ b/tosho_sjv/src/imaging.rs
@@ -69,7 +69,7 @@ fn draw_image(
 /// * `img_bytes` - Image bytes to descramble.
 ///
 /// # Example
-/// ```no_run
+/// ```rust,no_run
 /// use tosho_sjv::imaging::descramble_image;
 ///
 /// let img_bytes = [0_u8; 100];

--- a/tosho_sjv/src/lib.rs
+++ b/tosho_sjv/src/lib.rs
@@ -1,9 +1,4 @@
-#![warn(
-    missing_docs,
-    clippy::empty_docs,
-    rustdoc::broken_intra_doc_links,
-    clippy::missing_docs_in_private_items
-)]
+#![warn(missing_docs, clippy::empty_docs, rustdoc::broken_intra_doc_links)]
 #![doc = include_str!("../README.md")]
 
 use constants::{

--- a/tosho_sjv/src/lib.rs
+++ b/tosho_sjv/src/lib.rs
@@ -1,3 +1,9 @@
+#![warn(
+    missing_docs,
+    clippy::empty_docs,
+    rustdoc::broken_intra_doc_links,
+    clippy::missing_docs_in_private_items
+)]
 #![doc = include_str!("../README.md")]
 
 use constants::{

--- a/tosho_sjv/src/models/account.rs
+++ b/tosho_sjv/src/models/account.rs
@@ -94,12 +94,11 @@ impl AccountSubscription {
 /// This is a minimal representation of the subscription info.
 /// Some field are discarded for simplicity.
 #[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize)]
+#[auto_getters(unref = true)]
 pub struct AccountArchive {
     /// Is the request successful
-    #[copyable]
     ok: IntBool,
     /// The current subscription of the user
-    #[copyable]
     subscription_type: SubscriptionType,
     /// Read limit
     #[serde(rename = "archive_limit")]

--- a/tosho_sjv/src/models/account.rs
+++ b/tosho_sjv/src/models/account.rs
@@ -3,67 +3,68 @@
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
 use serde::{Deserialize, Serialize};
+use tosho_macros::AutoGetter;
 
 use super::{IntBool, SubscriptionType};
 
 /// A login result.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct AccountLoginResponse {
     /// The user ID.
     #[serde(rename = "user_id")]
-    pub id: u32,
+    id: u32,
     /// Username used for login.
     #[serde(rename = "login")]
-    pub username: String,
+    username: String,
     /// The session ID.
-    pub session_id: String,
+    session_id: String,
     /// The token used for requests.
     #[serde(rename = "trust_user_jwt")]
-    pub token: String,
+    token: String,
     /// ID token, not used for now.
     #[serde(rename = "trust_user_id_token")]
-    pub id_token: String,
+    id_token: String,
     /// Firebase token, used for communicating with Firebase.
     ///
     /// Not used for now.
     #[serde(rename = "firebase_auth_jwt")]
-    pub firebase_token: String,
+    firebase_token: String,
 }
 
 /// An account subscription info.
 ///
 /// This is a minimal representation of the subscription info.
 /// Some field are discarded for simplicity.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct AccountSubscription {
     /// The renewal status or type for SJ subscription.
     ///
     /// If `no` then it's not auto-renew, anything else is auto-renew.
     #[serde(rename = "is_auto_renew")]
-    pub sj_auto_renew: String,
+    sj_auto_renew: String,
     /// The renewal status or type for VM subscription.
     ///
     /// If `no` then it's not auto-renew, anything else is auto-renew.
     #[serde(rename = "vm_is_auto_renew")]
-    pub vm_auto_renew: String,
+    vm_auto_renew: String,
     /// The valid from date for SJ subscription.
     ///
     /// [`None`] if not subscribed.
     #[serde(rename = "valid_from")]
-    pub sj_valid_from: Option<i64>,
+    sj_valid_from: Option<i64>,
     /// The valid to date for SJ subscription.
     ///
     /// [`None`] if not subscribed.
     #[serde(rename = "valid_to")]
-    pub sj_valid_to: Option<i64>,
+    sj_valid_to: Option<i64>,
     /// The valid from date for VM subscription.
     ///
     /// [`None`] if not subscribed.
-    pub vm_valid_from: Option<i64>,
+    vm_valid_from: Option<i64>,
     /// The valid to date for VM subscription.
     ///
     /// [`None`] if not subscribed.
-    pub vm_valid_to: Option<i64>,
+    vm_valid_to: Option<i64>,
 }
 
 impl AccountSubscription {
@@ -92,28 +93,41 @@ impl AccountSubscription {
 ///
 /// This is a minimal representation of the subscription info.
 /// Some field are discarded for simplicity.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, AutoGetter, Serialize, Deserialize)]
 pub struct AccountArchive {
-    pub ok: IntBool,
-    pub subscription_type: SubscriptionType,
+    /// Is the request successful
+    #[copyable]
+    ok: IntBool,
+    /// The current subscription of the user
+    #[copyable]
+    subscription_type: SubscriptionType,
+    /// Read limit
     #[serde(rename = "archive_limit")]
-    pub read_limit: u32,
+    read_limit: u32,
+    /// Next read limit reset in seconds
     #[serde(rename = "archive_reset_seconds")]
-    pub read_reset: u32,
-    pub download_limit: u32,
+    read_reset: u32,
+    /// Download limit
+    download_limit: u32,
+    /// Download expiry in seconds
     #[serde(rename = "download_expire_seconds")]
-    pub download_expire: u32,
+    download_expire: u32,
+    /// The next reset for free reading
     #[serde(rename = "next_reset_epoch")]
-    pub next_reset: i64,
+    next_reset: i64,
+    /// The remaining number for free reading
     #[serde(rename = "num_remaining")]
-    pub remaining: u32,
+    remaining: u32,
 }
 
 /// A response for account entitlements.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct AccountEntitlementsResponse {
+    /// The user subscription information
     #[serde(rename = "subscription_info")]
-    pub subscriptions: AccountSubscription,
+    subscriptions: AccountSubscription,
+    /// The user archive information
     #[serde(rename = "archive_info")]
-    pub archive: AccountArchive,
+    #[copyable]
+    archive: AccountArchive,
 }

--- a/tosho_sjv/src/models/datetime.rs
+++ b/tosho_sjv/src/models/datetime.rs
@@ -1,6 +1,9 @@
+//! Serde related helper for datetime format in SJ/V
+
 use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Deserializer, Serializer};
 
+/// Serialize [`DateTime`] into a RFC3339 string that the API use.
 pub fn serialize<S>(date: &DateTime<FixedOffset>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -9,6 +12,7 @@ where
     serializer.serialize_str(&s)
 }
 
+/// Deserialize a RFC3339 string into [`DateTime`].
 pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<FixedOffset>, D::Error>
 where
     D: Deserializer<'de>,
@@ -18,6 +22,7 @@ where
     Ok(datetime)
 }
 
+/// Serialize an optional [`DateTime`] into a RFC3339 string that the API use.
 pub fn serialize_opt<S>(
     date: &Option<DateTime<FixedOffset>>,
     serializer: S,
@@ -34,6 +39,7 @@ where
     }
 }
 
+/// Deserialize an optional RFC3339 string into [`DateTime`].
 pub fn deserialize_opt<'de, D>(deserializer: D) -> Result<Option<DateTime<FixedOffset>>, D::Error>
 where
     D: Deserializer<'de>,

--- a/tosho_sjv/src/models/enums.rs
+++ b/tosho_sjv/src/models/enums.rs
@@ -67,7 +67,7 @@ impl From<IntBool> for bool {
 
 /// The subscription type
 ///
-/// ```
+/// ```rust
 /// use tosho_sjv::models::SubscriptionType;
 ///
 /// let st = SubscriptionType::VM;
@@ -112,7 +112,7 @@ impl std::fmt::Display for SubscriptionType {
 
 /// The manga rating
 ///
-/// ```
+/// ```rust
 /// use tosho_sjv::models::MangaRating;
 ///
 /// let st = MangaRating::AllAges;
@@ -215,7 +215,7 @@ impl MangaImprint {
     /// Get the pretty name of the imprint category.
     ///
     /// # Examples
-    /// ```
+    /// ```rust
     /// use tosho_sjv::models::MangaImprint;
     ///
     /// let ssunday = MangaImprint::ShonenSunday;

--- a/tosho_sjv/src/models/enums.rs
+++ b/tosho_sjv/src/models/enums.rs
@@ -2,7 +2,6 @@
 
 use std::str::FromStr;
 
-use serde::{Deserialize, Serialize};
 use tosho_macros::{
     enum_error, DeserializeEnum, DeserializeEnum32, DeserializeEnum32Fallback, EnumName,
     EnumU32Fallback, SerializeEnum, SerializeEnum32,

--- a/tosho_sjv/src/models/enums.rs
+++ b/tosho_sjv/src/models/enums.rs
@@ -8,7 +8,7 @@ use tosho_macros::{
 };
 
 /// A boolean type used by the API represented as an integer.
-#[derive(Debug, Clone, SerializeEnum32, DeserializeEnum32, EnumName)]
+#[derive(Debug, Clone, Copy, SerializeEnum32, DeserializeEnum32, EnumName)]
 pub enum IntBool {
     /// Property is false
     False = 0,
@@ -178,6 +178,7 @@ impl std::fmt::Display for MangaRating {
 #[derive(
     Debug,
     Clone,
+    Copy,
     SerializeEnum32,
     DeserializeEnum32Fallback,
     PartialEq,

--- a/tosho_sjv/src/models/manga.rs
+++ b/tosho_sjv/src/models/manga.rs
@@ -4,74 +4,80 @@
 
 use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Deserializer, Serialize};
+use tosho_macros::AutoGetter;
 
 use super::{MangaImprint, MangaRating, SimpleResponse, SubscriptionType};
 
 /// A node of a single chapter information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MangaChapterDetail {
     /// Chapter ID
-    pub id: u32,
+    id: u32,
     /// Chapter number, if [`None`] then it's not a chapter
-    pub chapter: Option<String>,
+    chapter: Option<String>,
     /// Volume number, if [`None`] then it's not a volume
-    pub volume: Option<u32>,
+    volume: Option<u32>,
     /// Chapter title
-    pub title: Option<String>,
+    title: Option<String>,
     /// Published date
     #[serde(
         rename = "publication_date",
         deserialize_with = "super::datetime::deserialize_opt",
         serialize_with = "super::datetime::serialize_opt"
     )]
-    pub published_at: Option<DateTime<FixedOffset>>,
+    #[copyable]
+    published_at: Option<DateTime<FixedOffset>>,
     /// Author of the chapter
-    pub author: String,
+    author: String,
     /// Thumbnail URL
     #[serde(rename = "thumburl")]
-    pub thumbnail: Option<String>,
+    thumbnail: Option<String>,
     /// Description of the chapter
-    pub description: String,
+    description: String,
     /// Associated series ID
     #[serde(rename = "manga_series_common_id")]
-    pub series_id: u32,
+    series_id: u32,
     /// Associated series title
-    pub series_title: String,
+    series_title: String,
     /// Associated series URL slug
     #[serde(rename = "series_vanityurl")]
-    pub series_slug: String,
+    series_slug: String,
     /// Associated series sort title
-    pub series_title_sort: String,
+    series_title_sort: String,
     /// Subscription type of the series
     ///
     /// If [`None`], the only way to read/download is to purchase it
-    pub subscription_type: Option<SubscriptionType>,
+    #[copyable]
+    subscription_type: Option<SubscriptionType>,
     /// Rating of the series
-    pub rating: MangaRating,
+    #[copyable]
+    rating: MangaRating,
     /// Total pages of the chapter
     #[serde(rename = "numpages")]
-    pub pages: u32,
+    pages: u32,
     /// Date of creation or added to the API
     #[serde(with = "super::datetime")]
-    pub created_at: DateTime<FixedOffset>,
+    #[copyable]
+    created_at: DateTime<FixedOffset>,
     /// Date of last update
     #[serde(
         deserialize_with = "super::datetime::deserialize_opt",
         serialize_with = "super::datetime::serialize_opt"
     )]
-    pub updated_at: Option<DateTime<FixedOffset>>,
+    #[copyable]
+    updated_at: Option<DateTime<FixedOffset>>,
     /// Date of read or download expiry
     #[serde(rename = "epoch_exp_date")]
-    pub expiry_at: Option<i64>,
+    expiry_at: Option<i64>,
     /// Is this a new chapter
-    pub new: bool,
+    new: bool,
     /// Is this chapter free
-    pub free: bool,
+    free: bool,
     /// Is this chapter featured
-    pub featured: bool,
+    featured: bool,
     /// Start page of the chapter
     #[serde(rename = "contents_start_page")]
-    pub start_page: u32,
+    start_page: u32,
 }
 
 impl MangaChapterDetail {
@@ -112,54 +118,58 @@ impl MangaChapterDetail {
 }
 
 /// A node of a single series information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MangaDetail {
     /// Series ID
-    pub id: u32,
+    id: u32,
     /// Series title
-    pub title: String,
+    title: String,
     /// Series tagline
-    pub tagline: Option<String>,
+    tagline: Option<String>,
     /// Series synopsis
-    pub synopsis: String,
+    synopsis: String,
     /// Series URL slug
     #[serde(rename = "vanityurl")]
-    pub slug: String,
+    slug: String,
     /// Series copyright info
-    pub copyright: String,
+    copyright: String,
     /// Series rating
-    pub rating: MangaRating,
+    #[copyable]
+    rating: MangaRating,
     /// Series thumbnail URL
     #[serde(rename = "link_img_url")]
-    pub thumbnail: String,
+    thumbnail: String,
     /// Series banner URL
     #[serde(rename = "keyart_url")]
-    pub keyart: Option<String>,
+    keyart: Option<String>,
     /// Series author
     #[serde(rename = "latest_author")]
-    pub author: Option<String>,
+    author: Option<String>,
     /// Series title sort
-    pub title_sort: String,
+    title_sort: String,
     /// Last updated date
     #[serde(with = "super::datetime")]
-    pub updated_at: DateTime<FixedOffset>,
+    #[copyable]
+    updated_at: DateTime<FixedOffset>,
     /// Subscription type of the series
     ///
     /// If [`None`], the only way to read/download is to purchase it
-    pub subscription_type: Option<SubscriptionType>,
+    #[copyable]
+    subscription_type: Option<SubscriptionType>,
     /// Imprint of the series
     #[serde(
         rename = "imprint_id",
         deserialize_with = "parse_imprint_extra",
         default
     )]
-    pub imprint: MangaImprint,
+    #[copyable]
+    imprint: MangaImprint,
     /// Total chapters of the series
     #[serde(rename = "num_chapters")]
-    pub total_chapters: u64,
+    total_chapters: u64,
     /// Total volumes of the series
     #[serde(rename = "num_gns")]
-    pub total_volumes: u64,
+    total_volumes: u64,
 }
 
 fn parse_imprint_extra<'de, D>(d: D) -> Result<MangaImprint, D::Error>
@@ -170,27 +180,29 @@ where
 }
 
 /// A node of a chapter notice information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct ChapterMessage {
     /// The message/notification
     #[serde(rename = "msg")]
-    pub message: String,
+    message: String,
     /// Starting chapter offset
-    pub offset: f64,
+    offset: f64,
     /// When the message will be shown
     #[serde(
         default,
         deserialize_with = "super::datetime::deserialize_opt",
         serialize_with = "super::datetime::serialize_opt"
     )]
-    pub show_from: Option<DateTime<FixedOffset>>,
+    #[copyable]
+    show_from: Option<DateTime<FixedOffset>>,
     /// When the message will stop being shown
     #[serde(
         default,
         deserialize_with = "super::datetime::deserialize_opt",
         serialize_with = "super::datetime::serialize_opt"
     )]
-    pub show_to: Option<DateTime<FixedOffset>>,
+    #[copyable]
+    show_to: Option<DateTime<FixedOffset>>,
 }
 
 impl ChapterMessage {
@@ -215,22 +227,22 @@ impl ChapterMessage {
 }
 
 /// A wrapper for [`MangaChapterDetail`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MangaChapterNode {
     /// The chapter information
     #[serde(rename = "manga")]
-    pub chapter: MangaChapterDetail,
+    chapter: MangaChapterDetail,
 }
 
 /// A response for requesting manga detail or chapter list
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MangaSeriesResponse {
     /// The notices for the chapter
     #[serde(rename = "chpt_msgs")]
-    pub notices: Vec<ChapterMessage>,
+    notices: Vec<ChapterMessage>,
     /// The data of the response
     #[serde(rename = "data")]
-    pub chapters: Vec<MangaChapterNode>,
+    chapters: Vec<MangaChapterNode>,
 }
 
 /// A wrapper for both MangaNode and MangaChapterNode
@@ -269,49 +281,49 @@ pub enum MangaStoreInfo {
 }
 
 /// A response for requesting cached manga list and featured data
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MangaStoreResponse {
     /// The data of the response
     #[serde(rename = "data")]
-    pub contents: Vec<MangaStoreInfo>,
+    contents: Vec<MangaStoreInfo>,
 }
 
 /// A response for verifying manga chapter ownership
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MangaAuthResponse {
     /// The data of the response
     #[serde(rename = "archive_info")]
-    pub info: SimpleResponse,
+    info: SimpleResponse,
 }
 
 /// A response for getting URL of a manga
 ///
 /// `url` will be [`None`] if you request for metadata and vice-versa
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MangaUrlResponse {
     /// The URL of the requested page
     #[serde(rename = "data", default)]
-    pub url: Option<String>,
+    url: Option<String>,
     /// The URL of the requested metadata
     #[serde(default)]
-    pub metadata: Option<String>,
+    metadata: Option<String>,
 }
 
 /// A response containing metadata of a chapter for reading
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct MangaReadMetadataResponse {
     /// The chapter title
-    pub title: String,
+    title: String,
     /// The chapter image height
-    pub height: u32,
+    height: u32,
     /// The chapter image width
-    pub width: u32,
+    width: u32,
     /// The chapter image height for HD quality
     #[serde(default, rename = "hdwidth")]
-    pub hd_width: Option<u32>,
+    hd_width: Option<u32>,
     /// The chapter image width for HD quality
     #[serde(default, rename = "hdheight")]
-    pub hd_height: Option<u32>,
+    hd_height: Option<u32>,
     // pages: Vec<_>,
     // spreads: Vec<_>,
 }

--- a/tosho_sjv/src/models/mod.rs
+++ b/tosho_sjv/src/models/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! If something is missing, please [open an issue](https://github.com/noaione/tosho-mango/issues/new/choose) or a [pull request](https://github.com/noaione/tosho-mango/compare).
 
+#![warn(clippy::missing_docs_in_private_items)]
+
 use serde::{Deserialize, Serialize};
 
 pub mod account;
@@ -18,8 +20,10 @@ use tosho_macros::AutoGetter;
 /// A simple response to check if request successful or not
 #[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct SimpleResponse {
+    /// Is the request succeed or not
     #[copyable]
     ok: IntBool,
+    /// The error message
     error: Option<String>,
 }
 

--- a/tosho_sjv/src/models/mod.rs
+++ b/tosho_sjv/src/models/mod.rs
@@ -13,12 +13,14 @@ pub use account::*;
 pub use enums::*;
 pub use manga::*;
 use tosho_common::FailableResponse;
+use tosho_macros::AutoGetter;
 
 /// A simple response to check if request successful or not
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AutoGetter, Serialize, Deserialize)]
 pub struct SimpleResponse {
-    pub ok: IntBool,
-    pub error: Option<String>,
+    #[copyable]
+    ok: IntBool,
+    error: Option<String>,
 }
 
 impl FailableResponse for SimpleResponse {

--- a/tosho_sjv/tests/models_test.rs
+++ b/tosho_sjv/tests/models_test.rs
@@ -107,25 +107,25 @@ fn test_store_cached_models() {
 
             let mut has_777 = false;
             let mut has_829_chapter = false;
-            for store_data in store_cached.contents {
+            for store_data in store_cached.contents() {
                 match &store_data {
                     tosho_sjv::models::MangaStoreInfo::Chapter(chapter) => {
-                        assert!(chapter.pages > 0);
+                        assert!(chapter.pages() > 0);
 
-                        if chapter.series_id == 829 {
-                            assert_eq!(chapter.series_slug, "aliens-area");
-                            assert_eq!(chapter.subscription_type, Some(SubscriptionType::SJ));
-                            assert_eq!(chapter.rating, MangaRating::Teen);
+                        if chapter.series_id() == 829 {
+                            assert_eq!(chapter.series_slug(), "aliens-area");
+                            assert_eq!(chapter.subscription_type(), Some(SubscriptionType::SJ));
+                            assert_eq!(chapter.rating(), MangaRating::Teen);
                             has_829_chapter = true;
                         }
                     }
                     tosho_sjv::models::MangaStoreInfo::Manga(manga) => {
-                        if manga.id == 777 {
-                            assert_eq!(manga.title, "Frieren: Beyond Journey’s End");
-                            assert_eq!(manga.slug, "frieren-the-journeys-end");
-                            assert_eq!(manga.subscription_type, Some(SubscriptionType::VM));
-                            assert_eq!(manga.imprint, MangaImprint::Undefined);
-                            assert_eq!(manga.rating, MangaRating::TeenPlus);
+                        if manga.id() == 777 {
+                            assert_eq!(manga.title(), "Frieren: Beyond Journey’s End");
+                            assert_eq!(manga.slug(), "frieren-the-journeys-end");
+                            assert_eq!(manga.subscription_type(), Some(SubscriptionType::VM));
+                            assert_eq!(manga.imprint(), MangaImprint::Undefined);
+                            assert_eq!(manga.rating(), MangaRating::TeenPlus);
                             has_777 = true;
                         }
                     }
@@ -173,7 +173,7 @@ fn test_store_cached_alt_models_loaded() {
                     );
                 }
             };
-            assert!(!store_cached.contents.is_empty())
+            assert!(!store_cached.contents().is_empty())
         }
     }
 }
@@ -211,9 +211,9 @@ fn test_manga_detail() {
                 }
             };
 
-            assert_eq!(manga_detail.notices[0].offset, 88.0);
-            let first_ch = &manga_detail.chapters[0].chapter;
-            assert_eq!(first_ch.chapter, Some("100.0".to_string()));
+            assert_eq!(manga_detail.notices()[0].offset(), 88.0);
+            let first_ch = manga_detail.chapters()[0].chapter();
+            assert_eq!(first_ch.chapter(), Some("100.0"));
         }
     }
 }


### PR DESCRIPTION
As title said, this PR makes all field in the models field private and in turns use a new macro called `AutoGetter` to automatically make a getter function for each field.

Checklist:
- [x] AM
- [x] KM
- [x] M+
- [x] MU
- [x] RB
- [x] SJ/V