### PR TITLE
Fix purchasing EventOrPaid chapters (musq)

### DIFF
--- a/tosho_musq/src/lib.rs
+++ b/tosho_musq/src/lib.rs
@@ -193,7 +193,7 @@ impl MUClient {
 
                 let need = chapter.price().saturating_sub(event);
                 if need == 0 {
-                    return Ok(self.build_coin(chapter.price(), chapter.price(), Some(0), Some(0)));
+                    return Ok(self.build_coin(chapter.price(), 0, Some(chapter.price()), Some(0)));
                 }
 
                 let need = need.saturating_sub(paid);
@@ -202,7 +202,7 @@ impl MUClient {
                     paid_diff = paid;
                 }
 
-                Ok(self.build_coin(chapter.price(), event, Some(paid_diff), Some(0)))
+                Ok(self.build_coin(chapter.price(), 0, Some(event), Some(paid_diff)))
             }
             ConsumptionType::Paid => {
                 let paid_left = user_point.paid().saturating_sub(chapter.price());

--- a/tosho_musq/src/lib.rs
+++ b/tosho_musq/src/lib.rs
@@ -709,7 +709,9 @@ mod tests {
         let user_point = TestUserPoint { free: 10, event: 10, paid: 10 }.to_proto();
         let chapter = TestChapterV2 { price: 0, consumption: ConsumptionType::Free }.to_proto();
 
-        let coin = client.calculate_coin(&user_point, &chapter);
+        let result = client.calculate_coin(&user_point, &chapter);
+        assert!(result.is_ok());
+        let coin = result.unwrap();
         assert_eq!(coin.get_free(), 0);
         assert_eq!(coin.get_event(), 0);
         assert_eq!(coin.get_paid(), 0);
@@ -723,7 +725,9 @@ mod tests {
         let user_point = TestUserPoint { free: 100, event: 0, paid: 0 }.to_proto();
         let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::Any }.to_proto();
 
-        let coin = client.calculate_coin(&user_point, &chapter);
+        let result = client.calculate_coin(&user_point, &chapter);
+        assert!(result.is_ok());
+        let coin = result.unwrap();
         assert_eq!(coin.get_free(), 50);
         assert_eq!(coin.get_event(), 0);
         assert_eq!(coin.get_paid(), 0);
@@ -737,7 +741,9 @@ mod tests {
         let user_point = TestUserPoint { free: 10, event: 40, paid: 0 }.to_proto();
         let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::Any }.to_proto();
 
-        let coin = client.calculate_coin(&user_point, &chapter);
+        let result = client.calculate_coin(&user_point, &chapter);
+        assert!(result.is_ok());
+        let coin = result.unwrap();
         assert_eq!(coin.get_free(), 10);
         assert_eq!(coin.get_event(), 40);
         assert_eq!(coin.get_paid(), 0);
@@ -751,7 +757,9 @@ mod tests {
         let user_point = TestUserPoint { free: 20, event: 10, paid: 30 }.to_proto();
         let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::Any }.to_proto();
 
-        let coin = client.calculate_coin(&user_point, &chapter);
+        let result = client.calculate_coin(&user_point, &chapter);
+        assert!(result.is_ok());
+        let coin = result.unwrap();
         assert_eq!(coin.get_free(), 20);
         assert_eq!(coin.get_event(), 10);
         assert_eq!(coin.get_paid(), 20);
@@ -765,7 +773,9 @@ mod tests {
         let user_point = TestUserPoint { free: 10, event: 10, paid: 10 }.to_proto();
         let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::Any }.to_proto();
 
-        let coin = client.calculate_coin(&user_point, &chapter);
+        let result = client.calculate_coin(&user_point, &chapter);
+        assert!(result.is_ok());
+        let coin = result.unwrap();
         assert_eq!(coin.get_free(), 10);
         assert_eq!(coin.get_event(), 10);
         assert_eq!(coin.get_paid(), 10);
@@ -779,7 +789,9 @@ mod tests {
         let user_point = TestUserPoint { free: 0, event: 50, paid: 0 }.to_proto();
         let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::EventOrPaid }.to_proto();
 
-        let coin = client.calculate_coin(&user_point, &chapter);
+        let result = client.calculate_coin(&user_point, &chapter);
+        assert!(result.is_ok());
+        let coin = result.unwrap();
         assert_eq!(coin.get_free(), 0);
         assert_eq!(coin.get_event(), 50);
         assert_eq!(coin.get_paid(), 0);
@@ -793,7 +805,9 @@ mod tests {
         let user_point = TestUserPoint { free: 0, event: 10, paid: 40 }.to_proto();
         let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::EventOrPaid }.to_proto();
 
-        let coin = client.calculate_coin(&user_point, &chapter);
+        let result = client.calculate_coin(&user_point, &chapter);
+        assert!(result.is_ok());
+        let coin = result.unwrap();
         assert_eq!(coin.get_free(), 0);
         assert_eq!(coin.get_event(), 10);
         assert_eq!(coin.get_paid(), 40);
@@ -807,7 +821,9 @@ mod tests {
         let user_point = TestUserPoint { free: 160, event: 840, paid: 0 }.to_proto();
         let chapter = TestChapterV2 { price: 40, consumption: ConsumptionType::EventOrPaid }.to_proto();
 
-        let coin = client.calculate_coin(&user_point, &chapter);
+        let result = client.calculate_coin(&user_point, &chapter);
+        assert!(result.is_ok());
+        let coin = result.unwrap();
         assert_eq!(coin.get_free(), 0);
         assert_eq!(coin.get_event(), 40);
         assert_eq!(coin.get_paid(), 0);
@@ -821,7 +837,9 @@ mod tests {
         let user_point = TestUserPoint { free: 0, event: 0, paid: 100 }.to_proto();
         let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::Paid }.to_proto();
 
-        let coin = client.calculate_coin(&user_point, &chapter);
+        let result = client.calculate_coin(&user_point, &chapter);
+        assert!(result.is_ok());
+        let coin = result.unwrap();
         assert_eq!(coin.get_free(), 0);
         assert_eq!(coin.get_event(), 0);
         assert_eq!(coin.get_paid(), 50);
@@ -835,7 +853,9 @@ mod tests {
         let user_point = TestUserPoint { free: 0, event: 40, paid: 10 }.to_proto();
         let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::Paid }.to_proto();
 
-        let coin = client.calculate_coin(&user_point, &chapter);
+        let result = client.calculate_coin(&user_point, &chapter);
+        assert!(result.is_ok());
+        let coin = result.unwrap();
         assert_eq!(coin.get_free(), 0);
         assert_eq!(coin.get_event(), 0);
         assert_eq!(coin.get_paid(), 0);

--- a/tosho_musq/src/lib.rs
+++ b/tosho_musq/src/lib.rs
@@ -167,19 +167,18 @@ impl MUClient {
                 let event = user_point.event();
                 let paid = user_point.paid();
 
-                let need = ((chapter.price() - free) as i64).max(0);
-                if need <= 0 {
+                let need = chapter.price().saturating_sub(free);
+                if need == 0 {
                     return Ok(self.build_coin(chapter.price(), chapter.price(), Some(0), Some(0)));
                 }
 
-                let need = (need - event as i64).max(0);
-                if need <= 0 {
+                let need = need.saturating_sub(event);
+                if need == 0 {
                     let event_diff = chapter.price().saturating_sub(free);
-
                     return Ok(self.build_coin(chapter.price(), free, Some(event_diff), Some(0)));
                 }
 
-                let need = (need - paid as i64).max(0);
+                let need = need.saturating_sub(paid);
                 let mut paid_diff = chapter.price().saturating_sub(free).saturating_sub(event);
                 if need > 0 {
                     paid_diff = paid;
@@ -192,12 +191,12 @@ impl MUClient {
                 let event = user_point.event();
                 let paid = user_point.paid();
 
-                let need = ((chapter.price() - event) as i64).max(0);
-                if need <= 0 {
+                let need = chapter.price().saturating_sub(event);
+                if need == 0 {
                     return Ok(self.build_coin(chapter.price(), chapter.price(), Some(0), Some(0)));
                 }
 
-                let need = (need - paid as i64).max(0);
+                let need = need.saturating_sub(paid);
                 let mut paid_diff = chapter.price().saturating_sub(event);
                 if need > 0 {
                     paid_diff = paid;
@@ -206,9 +205,9 @@ impl MUClient {
                 Ok(self.build_coin(chapter.price(), event, Some(paid_diff), Some(0)))
             }
             ConsumptionType::Paid => {
-                let paid_left: i64 = user_point.paid() as i64 - chapter.price() as i64;
+                let paid_left = user_point.paid().saturating_sub(chapter.price());
 
-                if paid_left < 0 {
+                if paid_left == 0 {
                     return Ok(self.build_coin(chapter.price(), 0, Some(0), Some(0)));
                 }
 

--- a/tosho_musq/src/lib.rs
+++ b/tosho_musq/src/lib.rs
@@ -608,3 +608,194 @@ pub fn decrypt_image(image: &[u8], page: &proto::ChapterPage) -> ToshoResult<Vec
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::LazyLock;
+    use super::*;
+    use crate::proto::ConsumptionType;
+
+    // Minimal stubs for UserPoint and ChapterV2 for testing
+    #[derive(Default)]
+    struct TestUserPoint {
+        free: u64,
+        event: u64,
+        paid: u64,
+    }
+    impl TestUserPoint {
+        fn to_proto(&self) -> UserPoint {
+            let mut up = UserPoint::default();
+            up.set_free(self.free);
+            up.set_event(self.event);
+            up.set_paid(self.paid);
+            up
+        }
+    }
+
+    #[derive(Default)]
+    struct TestChapterV2 {
+        price: u64,
+        consumption: ConsumptionType,
+    }
+    impl TestChapterV2 {
+        fn to_proto(&self) -> ChapterV2 {
+            let mut ch = ChapterV2::default();
+            ch.set_price(self.price);
+            ch.set_consumption(self.consumption.clone());
+            ch
+        }
+    }
+
+    fn dummy_client() -> MUClient {
+        static CONSTS: LazyLock<Constants> = LazyLock::new(|| {
+            Constants {
+                image_ua: "Dalvik/2.1.0 (Linux; U; Android 12; SM-G935F Build/SQ3A.220705.004)".to_string(),
+                api_ua: "okhttp/4.12.0".to_string(),
+                os_ver: "32", // Android SDK 12
+                app_ver: "73".to_string(),
+            }
+        });
+
+        MUClient::new("dummy", &CONSTS).unwrap()
+    }
+
+    #[test]
+    fn test_calculate_coin_type_free_should_use_no_currency() {
+        let client = dummy_client();
+        let user_point = TestUserPoint { free: 10, event: 10, paid: 10 }.to_proto();
+        let chapter = TestChapterV2 { price: 0, consumption: ConsumptionType::Free }.to_proto();
+
+        let coin = client.calculate_coin(&user_point, &chapter);
+        assert_eq!(coin.get_free(), 0);
+        assert_eq!(coin.get_event(), 0);
+        assert_eq!(coin.get_paid(), 0);
+        assert_eq!(coin.get_need(), 0);
+        assert!(coin.is_possible());
+    }
+
+    #[test]
+    fn test_calculate_coin_type_any_with_enough_free_should_be_possible() {
+        let client = dummy_client();
+        let user_point = TestUserPoint { free: 100, event: 0, paid: 0 }.to_proto();
+        let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::Any }.to_proto();
+
+        let coin = client.calculate_coin(&user_point, &chapter);
+        assert_eq!(coin.get_free(), 50);
+        assert_eq!(coin.get_event(), 0);
+        assert_eq!(coin.get_paid(), 0);
+        assert_eq!(coin.get_need(), 50);
+        assert!(coin.is_possible());
+    }
+
+    #[test]
+    fn test_calculate_coin_type_any_should_supplement_with_event() {
+        let client = dummy_client();
+        let user_point = TestUserPoint { free: 10, event: 40, paid: 0 }.to_proto();
+        let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::Any }.to_proto();
+
+        let coin = client.calculate_coin(&user_point, &chapter);
+        assert_eq!(coin.get_free(), 10);
+        assert_eq!(coin.get_event(), 40);
+        assert_eq!(coin.get_paid(), 0);
+        assert_eq!(coin.get_need(), 50);
+        assert!(coin.is_possible());
+    }
+
+    #[test]
+    fn test_calculate_coin_type_any_should_maximise_use_of_less_valuable_currencies() {
+        let client = dummy_client();
+        let user_point = TestUserPoint { free: 20, event: 10, paid: 30 }.to_proto();
+        let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::Any }.to_proto();
+
+        let coin = client.calculate_coin(&user_point, &chapter);
+        assert_eq!(coin.get_free(), 20);
+        assert_eq!(coin.get_event(), 10);
+        assert_eq!(coin.get_paid(), 20);
+        assert_eq!(coin.get_need(), 50);
+        assert!(coin.is_possible());
+    }
+
+    #[test]
+    fn test_calculate_coin_type_any_should_not_be_possible_when_not_enough_currency() {
+        let client = dummy_client();
+        let user_point = TestUserPoint { free: 10, event: 10, paid: 10 }.to_proto();
+        let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::Any }.to_proto();
+
+        let coin = client.calculate_coin(&user_point, &chapter);
+        assert_eq!(coin.get_free(), 10);
+        assert_eq!(coin.get_event(), 10);
+        assert_eq!(coin.get_paid(), 10);
+        assert_eq!(coin.get_need(), 50);
+        assert!(!coin.is_possible());
+    }
+
+    #[test]
+    fn test_calculate_coin_type_event_or_paid_enough_event_should_be_possible() {
+        let client = dummy_client();
+        let user_point = TestUserPoint { free: 0, event: 50, paid: 0 }.to_proto();
+        let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::EventOrPaid }.to_proto();
+
+        let coin = client.calculate_coin(&user_point, &chapter);
+        assert_eq!(coin.get_free(), 0);
+        assert_eq!(coin.get_event(), 50);
+        assert_eq!(coin.get_paid(), 0);
+        assert_eq!(coin.get_need(), 50);
+        assert!(coin.is_possible());
+    }
+
+    #[test]
+    fn test_calculate_coin_type_event_or_paid_should_supplement_with_paid() {
+        let client = dummy_client();
+        let user_point = TestUserPoint { free: 0, event: 10, paid: 40 }.to_proto();
+        let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::EventOrPaid }.to_proto();
+
+        let coin = client.calculate_coin(&user_point, &chapter);
+        assert_eq!(coin.get_free(), 0);
+        assert_eq!(coin.get_event(), 10);
+        assert_eq!(coin.get_paid(), 40);
+        assert_eq!(coin.get_need(), 50);
+        assert!(coin.is_possible());
+    }
+
+    #[test]
+    fn test_calculate_coin_type_event_or_paid_should_not_try_to_use_free() {
+        let client = dummy_client();
+        let user_point = TestUserPoint { free: 160, event: 840, paid: 0 }.to_proto();
+        let chapter = TestChapterV2 { price: 40, consumption: ConsumptionType::EventOrPaid }.to_proto();
+
+        let coin = client.calculate_coin(&user_point, &chapter);
+        assert_eq!(coin.get_free(), 0);
+        assert_eq!(coin.get_event(), 40);
+        assert_eq!(coin.get_paid(), 0);
+        assert_eq!(coin.get_need(), 40);
+        assert!(coin.is_possible());
+    }
+
+    #[test]
+    fn test_calculate_coin_type_paid_enough_should_be_possible() {
+        let client = dummy_client();
+        let user_point = TestUserPoint { free: 0, event: 0, paid: 100 }.to_proto();
+        let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::Paid }.to_proto();
+
+        let coin = client.calculate_coin(&user_point, &chapter);
+        assert_eq!(coin.get_free(), 0);
+        assert_eq!(coin.get_event(), 0);
+        assert_eq!(coin.get_paid(), 50);
+        assert_eq!(coin.get_need(), 50);
+        assert!(coin.is_possible());
+    }
+
+    #[test]
+    fn test_calculate_coin_type_paid_zeros_out_usage_when_not_possible() {
+        let client = dummy_client();
+        let user_point = TestUserPoint { free: 0, event: 40, paid: 10 }.to_proto();
+        let chapter = TestChapterV2 { price: 50, consumption: ConsumptionType::Paid }.to_proto();
+
+        let coin = client.calculate_coin(&user_point, &chapter);
+        assert_eq!(coin.get_free(), 0);
+        assert_eq!(coin.get_event(), 0);
+        assert_eq!(coin.get_paid(), 0);
+        assert_eq!(coin.get_need(), 50);
+        assert!(!coin.is_possible());
+    }
+}

--- a/tosho_musq/src/proto/chapter.rs
+++ b/tosho_musq/src/proto/chapter.rs
@@ -170,6 +170,14 @@ impl ChapterV2 {
     }
 }
 
+#[cfg(test)]
+impl ChapterV2 {
+    /// For testing purposes, set the chapter price.
+    pub fn set_price(&mut self, value: u64) {
+        self.price = value;
+    }
+}
+
 impl From<ChapterV2> for Chapter {
     fn from(value: ChapterV2) -> Self {
         Self {


### PR DESCRIPTION
Purchasing EventOrPaid chapters was placing `chapter.price()` in the `free_coin` argument slot instead of in `event_coin`.

Added unit tests to catch issues before I fixed it (tests created via Copilot so they're probably not the greatest but they do cover what I encountered).

Fixed overflow errors I encountered while debugging.

Also, a note about ConsumptionType::Free/Rental/Purchased/Subscription: `need_coin` is always set to the price and the others are 0/`None`, so they never get `true` from `is_possible()`. No idea if that's intended.

Also also, the default arm in the switch statement is intended to cover undefined enum cases... but it looks like the getter for `consumption` returns `ConsumptionType::default()` for invalid values, and `default()` is set to `Any`:

```rust
#[allow(dead_code)]
impl ChapterV2 {
    ///Returns the value of `subtitle`, or the default value if `subtitle` is unset.
    pub fn subtitle(&self) -> &str {
        match self.subtitle {
            ::core::option::Option::Some(ref val) => &val[..],
            ::core::option::Option::None => "",
        }
    }
    ///Returns the enum value of `consumption`, or the default if the field is set to an invalid enum value.
    pub fn consumption(&self) -> ConsumptionType {
        ::core::convert::TryFrom::try_from(self.consumption)
            .unwrap_or(ConsumptionType::default())
    }
```

```rust
impl ::core::default::Default for ConsumptionType {
    fn default() -> ConsumptionType {
        ConsumptionType::Any
    }
}
```

Also also _also_, found an issue with the update checker - `updater.get_latest_release()` calls `reqwest::blocking::ClientBuilder` internally which makes tokio shit itself. Don't think I've ever seen it outside debugging, though. I'll maybe raise a separate PR for it if I get round to fixing it.