### PR TITLE
refactor!: change all static b64 decoding to a comptime constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,7 +2425,6 @@ dependencies = [
 name = "tosho-amap"
 version = "0.7.0"
 dependencies = [
- "base64",
  "chrono",
  "futures-util",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,7 +2515,6 @@ dependencies = [
 name = "tosho-rbean"
 version = "0.5.0"
 dependencies = [
- "base64",
  "chrono",
  "futures-util",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,6 +2475,7 @@ dependencies = [
 name = "tosho-macros"
 version = "0.5.0"
 dependencies = [
+ "base64",
  "proc-macro2",
  "prost",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,6 @@ name = "tosho-musq"
 version = "0.7.0"
 dependencies = [
  "aes",
- "base64",
  "cbc",
  "chrono",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,7 +2453,6 @@ dependencies = [
 name = "tosho-kmkc"
 version = "0.7.0"
 dependencies = [
- "base64",
  "chrono",
  "futures-util",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,7 +2486,6 @@ dependencies = [
 name = "tosho-mplus"
 version = "0.4.0"
 dependencies = [
- "base64",
  "chrono",
  "futures-util",
  "prost",

--- a/tosho/src/impl/amap/common.rs
+++ b/tosho/src/impl/amap/common.rs
@@ -32,7 +32,7 @@ pub(super) fn do_print_search_information(
     for (idx, result) in results.iter().enumerate() {
         let result = result.info();
         let id = result.id();
-        let manga_url = format!("https://{}/manga/{}", &*BASE_HOST, id);
+        let manga_url = format!("https://{}/manga/{}", BASE_HOST, id);
         let linked = linkify!(&manga_url, result.title());
         let mut text_data = cformat!("<s>{}</s> ({})", linked, id);
 
@@ -212,7 +212,7 @@ pub(super) fn save_session_config(client: &AMClient, config: &Config) {
 
     let session = store
         .iter_any()
-        .find(|&cookie| cookie.name() == *SESSION_COOKIE_NAME);
+        .find(|&cookie| cookie.name() == SESSION_COOKIE_NAME);
 
     if let Some(session) = session {
         config.session = session.value().to_string();

--- a/tosho/src/impl/amap/manga.rs
+++ b/tosho/src/impl/amap/manga.rs
@@ -63,7 +63,7 @@ pub(crate) async fn amap_title_info(
     match results {
         Ok(results) => {
             let info = results.info();
-            let manga_url = format!("https://{}/manga/{}", &*BASE_HOST, title_id);
+            let manga_url = format!("https://{}/manga/{}", BASE_HOST, title_id);
             let linked = linkify!(&manga_url, info.title());
 
             console.info(cformat!(

--- a/tosho/src/impl/kmkc/common.rs
+++ b/tosho/src/impl/kmkc/common.rs
@@ -26,7 +26,7 @@ pub(super) fn do_print_search_information(
 
     for (idx, result) in results.iter().enumerate() {
         let id = result.id();
-        let manga_url = format!("https://{}/title/{}", &*BASE_HOST, id);
+        let manga_url = format!("https://{}/title/{}", BASE_HOST, id);
         let linked = linkify!(&manga_url, result.title());
         let mut text_data = cformat!("<s>{}</s> ({})", linked, id);
         if let Some(next_update) = result.next_update() {

--- a/tosho/src/impl/kmkc/manga.rs
+++ b/tosho/src/impl/kmkc/manga.rs
@@ -172,7 +172,7 @@ pub(crate) async fn kmkc_title_info(
                 }
             }
 
-            let manga_url = format!("https://{}/title/{}", &*BASE_HOST, title_id);
+            let manga_url = format!("https://{}/title/{}", BASE_HOST, title_id);
             let linked = linkify!(&manga_url, result.title());
 
             console.info(cformat!(

--- a/tosho/src/impl/kmkc/purchases.rs
+++ b/tosho/src/impl/kmkc/purchases.rs
@@ -218,7 +218,7 @@ pub(crate) async fn kmkc_purchased(
             ));
 
             for result in results {
-                let manga_url = format!("https://{}/title/{}", &*BASE_HOST, result.id());
+                let manga_url = format!("https://{}/title/{}", BASE_HOST, result.id());
                 let linked = linkify!(&manga_url, result.title());
 
                 console.info(cformat!("  {} ({})", linked, result.id()));

--- a/tosho/src/impl/mplus/common.rs
+++ b/tosho/src/impl/mplus/common.rs
@@ -18,7 +18,7 @@ pub(super) fn do_print_search_information(
     let spacing = spacing.unwrap_or(2);
 
     for (idx, result) in results.iter().enumerate() {
-        let manga_url = format!("https://{}/titles/{}", &*BASE_HOST, result.id());
+        let manga_url = format!("https://{}/titles/{}", BASE_HOST, result.id());
         let linked = linkify!(&manga_url, result.title());
         let mut text_data = cformat!("<s>{}</s> ({})", linked, result.id());
 

--- a/tosho/src/impl/mplus/manga.rs
+++ b/tosho/src/impl/mplus/manga.rs
@@ -53,7 +53,7 @@ fn format_other_languages(title_lang: &[TitleLanguages]) -> String {
     title_lang
         .iter()
         .map(|lang| {
-            let lang_url = format!("https://{}/titles/{}", &*BASE_HOST, lang.id());
+            let lang_url = format!("https://{}/titles/{}", BASE_HOST, lang.id());
             let linked = linkify!(&lang_url, &lang.language().pretty_name());
             cformat!("<p(244),reverse,bold>{}</>", linked)
         })
@@ -78,7 +78,7 @@ pub(crate) async fn mplus_title_info(
     match result {
         Ok(tosho_mplus::APIResponse::Success(title_info)) => {
             let title = title_info.title().unwrap();
-            let manga_url = format!("https://{}/titles/{}", &*BASE_HOST, title.id());
+            let manga_url = format!("https://{}/titles/{}", BASE_HOST, title.id());
             let linked = linkify!(manga_url, title.title());
 
             console.info(cformat!(
@@ -162,7 +162,7 @@ pub(crate) async fn mplus_title_info(
 
             if show_chapters && !all_chapters.is_empty() {
                 for chapter in all_chapters {
-                    let ch_url = format!("https://{}/viewer/{}", &*BASE_HOST, chapter.chapter_id());
+                    let ch_url = format!("https://{}/viewer/{}", BASE_HOST, chapter.chapter_id());
                     let linked_ch = linkify!(ch_url, chapter.title());
                     let mut base_txt =
                         cformat!("    <s>{}</> ({})", linked_ch, chapter.chapter_id());

--- a/tosho/src/impl/musq/common.rs
+++ b/tosho/src/impl/musq/common.rs
@@ -21,7 +21,7 @@ pub(super) fn do_print_search_information(
     let spacing = spacing.unwrap_or(2);
 
     for (idx, result) in results.iter().enumerate() {
-        let manga_url = format!("https://{}/manga/{}", &*BASE_HOST, result.id());
+        let manga_url = format!("https://{}/manga/{}", BASE_HOST, result.id());
         let linked = linkify!(&manga_url, result.title());
         let mut text_data = color_print::cformat!("<s>{}</s> ({})", linked, result.id());
 

--- a/tosho/src/impl/musq/manga.rs
+++ b/tosho/src/impl/musq/manga.rs
@@ -85,7 +85,7 @@ pub(crate) async fn musq_search_weekly(
 fn format_tags(tags: &[Tag]) -> String {
     tags.iter()
         .map(|tag| {
-            let tag_url = format!("https://{}/genre/{}", &*BASE_HOST, tag.id());
+            let tag_url = format!("https://{}/genre/{}", BASE_HOST, tag.id());
             let linked = linkify!(&tag_url, &tag.name());
 
             cformat!("<p(244),reverse,bold>{}</>", linked)
@@ -114,7 +114,7 @@ pub(crate) async fn musq_title_info(
             1
         }
         Ok(result) => {
-            let manga_url = format!("https://{}/manga/{}", &*BASE_HOST, title_id);
+            let manga_url = format!("https://{}/manga/{}", BASE_HOST, title_id);
             let linked = linkify!(&manga_url, &result.title());
 
             console.info(cformat!(

--- a/tosho/src/impl/rbean/common.rs
+++ b/tosho/src/impl/rbean/common.rs
@@ -14,7 +14,7 @@ pub(super) fn do_print_single_information(
     let term = get_console(0);
     let spacing = spacing.unwrap_or(2);
 
-    let manga_url = format!("https://{}/series/{}", &*BASE_HOST, result.slug());
+    let manga_url = format!("https://{}/series/{}", BASE_HOST, result.slug());
     let linked = linkify!(&manga_url, &result.title());
     let text_data = cformat!("<s>{}</s> ({})", linked, result.uuid());
 
@@ -39,7 +39,7 @@ pub(super) fn do_print_single_information(
         for chapter in chapter_info.iter() {
             let chapter_url = format!(
                 "https://{}/series/{}/chapter/{}",
-                &*BASE_HOST,
+                BASE_HOST,
                 result.slug(),
                 chapter.uuid()
             );

--- a/tosho/src/impl/rbean/favorites.rs
+++ b/tosho/src/impl/rbean/favorites.rs
@@ -33,7 +33,7 @@ pub(crate) async fn rbean_read_list(
                 if let Some(chapter) = result.chapter() {
                     let linked_ch = format!(
                         "https://{}/series/{}/read/{}",
-                        &*BASE_HOST,
+                        BASE_HOST,
                         manga.slug(),
                         chapter.uuid()
                     );

--- a/tosho/src/impl/rbean/manga.rs
+++ b/tosho/src/impl/rbean/manga.rs
@@ -166,7 +166,7 @@ pub(crate) async fn rbean_title_info(
         save_session_config(client, account);
     }
 
-    let manga_url = format!("https://{}/series/{}", &*BASE_HOST, result.slug());
+    let manga_url = format!("https://{}/series/{}", BASE_HOST, result.slug());
     let linked = linkify!(&manga_url, result.title());
 
     console.info(cformat!(
@@ -185,7 +185,7 @@ pub(crate) async fn rbean_title_info(
         .genres()
         .iter()
         .map(|g| {
-            let genre_url = format!("https://{}/series?tags={}", &*BASE_HOST, g.slug());
+            let genre_url = format!("https://{}/series?tags={}", BASE_HOST, g.slug());
             linkify!(&genre_url, g.name())
         })
         .collect();
@@ -195,7 +195,7 @@ pub(crate) async fn rbean_title_info(
 
     let publish_url = format!(
         "https://{}/publishers/{}",
-        &*BASE_HOST,
+        BASE_HOST,
         result.publisher().slug()
     );
     let linked_pub = linkify!(&publish_url, result.publisher().name());

--- a/tosho/src/impl/rbean/rankings.rs
+++ b/tosho/src/impl/rbean/rankings.rs
@@ -31,7 +31,7 @@ pub(crate) async fn rbean_home_page(
             console.info(cformat!("Home page for <m,s>{}</>", account.id));
 
             if let Some(hero_manga) = results.hero().manga() {
-                let manga_url = format!("https://{}/series/{}", &*BASE_HOST, hero_manga.slug());
+                let manga_url = format!("https://{}/series/{}", BASE_HOST, hero_manga.slug());
                 let linked_url = linkify!(manga_url, hero_manga.title());
                 console.info(cformat!(">> <m,s>{}</> <<", linked_url));
                 console.info(&manga_url);
@@ -53,8 +53,7 @@ pub(crate) async fn rbean_home_page(
             }
 
             for featured in results.featured().iter() {
-                let manga_url =
-                    format!("https://{}/series/{}", &*BASE_HOST, featured.manga().slug());
+                let manga_url = format!("https://{}/series/{}", BASE_HOST, featured.manga().slug());
                 let linked_url = linkify!(manga_url, &featured.manga().title());
                 console.info(cformat!(
                     " <m,s>{}</>: <s>{}</>",

--- a/tosho/src/impl/sjv/common.rs
+++ b/tosho/src/impl/sjv/common.rs
@@ -19,7 +19,7 @@ pub(super) fn do_print_search_information(
 
     for (idx, result) in results.iter().enumerate() {
         let id = result.id();
-        let manga_url = format!("https://{}/{}", &*BASE_HOST, result.slug());
+        let manga_url = format!("https://{}/{}", BASE_HOST, result.slug());
         let linked = linkify!(&manga_url, result.title());
         let text_data = cformat!("<s>{}</s> ({})", linked, id);
 

--- a/tosho/src/impl/sjv/manga.rs
+++ b/tosho/src/impl/sjv/manga.rs
@@ -129,7 +129,7 @@ pub(crate) async fn sjv_title_info(
 
             let manga_url = format!(
                 "https://{}/{}",
-                &*tosho_sjv::constants::BASE_HOST,
+                tosho_sjv::constants::BASE_HOST,
                 result.slug()
             );
             let linked = linkify!(&manga_url, result.title());
@@ -194,8 +194,8 @@ pub(crate) async fn sjv_title_info(
                         Some(tosho_sjv::models::SubscriptionType::SJ) => {
                             format!(
                                 "https://{}/{}/{}/chapter/{}?action=read",
-                                &*tosho_sjv::constants::BASE_HOST,
-                                &*EXPAND_SJ_NAME,
+                                tosho_sjv::constants::BASE_HOST,
+                                EXPAND_SJ_NAME,
                                 result.slug(),
                                 chapter.id()
                             )
@@ -203,8 +203,8 @@ pub(crate) async fn sjv_title_info(
                         Some(tosho_sjv::models::SubscriptionType::VM) => {
                             format!(
                                 "https://{}/{}/{}/chapter/{}?action=read",
-                                &*tosho_sjv::constants::BASE_HOST,
-                                &*EXPAND_VM_NAME,
+                                tosho_sjv::constants::BASE_HOST,
+                                EXPAND_VM_NAME,
                                 result.slug(),
                                 chapter.id()
                             )

--- a/tosho_amap/Cargo.toml
+++ b/tosho_amap/Cargo.toml
@@ -23,7 +23,6 @@ serde_json.workspace = true
 reqwest = { workspace = true, features = ["cookies", "json"] }
 reqwest_cookie_store.workspace = true
 
-base64.workspace = true
 chrono.workspace = true
 sha2.workspace = true
 

--- a/tosho_amap/src/constants.rs
+++ b/tosho_amap/src/constants.rs
@@ -10,7 +10,7 @@
 
 use std::sync::LazyLock;
 
-use base64::{Engine as _, engine::general_purpose};
+use tosho_macros::comptime_b64;
 
 /// A struct containing constants used in the library.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -28,21 +28,14 @@ pub struct Constants {
 /// A struct containing the header names used in the library.
 #[derive(Debug, Clone)]
 pub struct HeaderMapping {
-    pub(crate) i: String,
-    pub(crate) t: String,
-    pub(crate) s: String,
-    pub(crate) n: String,
+    pub(crate) i: &'static str,
+    pub(crate) t: &'static str,
+    pub(crate) s: &'static str,
+    pub(crate) n: &'static str,
 }
 
 /// The name of the application.
-pub static APP_NAME: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("QWxwaGFNYW5nYQ==")
-            .expect("Failed to decode base64 APP_NAME"),
-    )
-    .expect("Invalid base64 string (APP_NAME)")
-});
+pub const APP_NAME: &str = comptime_b64!("QWxwaGFNYW5nYQ==");
 
 /// The constants used for Android devices.
 pub static ANDROID_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
@@ -50,7 +43,7 @@ pub static ANDROID_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
 
     let main_ua: String = format!(
         "Dalvik/2.1.0 (Linux; U; Android 11; SM-S908E Build/TP1A.220624.014) {}/{}",
-        *APP_NAME, app_version
+        APP_NAME, app_version
     );
 
     Constants {
@@ -62,94 +55,30 @@ pub static ANDROID_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
 });
 
 /// The base API used for overall requests.
-pub static BASE_API: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aHR0cHM6Ly9hcGkuYWxwaGEtbWFuZ2EuY29tL2FwaS9lbg==")
-            .expect("Failed to decode base64 BASE_API"),
-    )
-    .expect("Invalid base64 string (BASE_API)")
-});
+pub const BASE_API: &str =
+    tosho_macros::comptime_b64!("aHR0cHM6Ly9hcGkuYWxwaGEtbWFuZ2EuY29tL2FwaS9lbg==");
 /// The base image URL used for image requests.
-pub static BASE_IMG: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aHR0cHM6Ly9pbWFnZS1lbi5hbHBoYS1tYW5nYS5jb20=")
-            .expect("Failed to decode base64 BASE_IMG"),
-    )
-    .expect("Invalid base64 string (BASE_IMG)")
-});
+pub const BASE_IMG: &str = comptime_b64!("aHR0cHM6Ly9pbWFnZS1lbi5hbHBoYS1tYW5nYS5jb20=");
 
 /// The base host used for overall requests.
-pub static BASE_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("YWxwaGEtbWFuZ2EuY29t")
-            .expect("Failed to decode base64 BASE_HOST"),
-    )
-    .expect("Invalid base64 string (BASE_HOST)")
-});
+pub const BASE_HOST: &str = comptime_b64!("YWxwaGEtbWFuZ2EuY29t");
 /// The API host used for API requests.
-pub static API_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("YXBpLmFscGhhLW1hbmdhLmNvbQ==")
-            .expect("Failed to decode base64 API_HOST"),
-    )
-    .expect("Invalid base64 string (API_HOST)")
-});
+pub const API_HOST: &str = comptime_b64!("YXBpLmFscGhhLW1hbmdhLmNvbQ==");
 /// The image host used for image requests.
-pub static IMAGE_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aW1hZ2UtZW4uYWxwaGEtbWFuZ2EuY29t")
-            .expect("Failed to decode base64 IMAGE_HOST"),
-    )
-    .expect("Invalid base64 string (IMAGE_HOST)")
-});
+pub const IMAGE_HOST: &str = comptime_b64!("aW1hZ2UtZW4uYWxwaGEtbWFuZ2EuY29t");
 
 /// Constants used for header names.
 pub(crate) static HEADER_NAMES: LazyLock<HeaderMapping> = LazyLock::new(|| {
-    let i = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("YXAtYXV0aC1pZGVudGlmaWVy")
-            .expect("Failed to decode base64 HEADER_NAME_I"),
-    )
-    .expect("Invalid base64 string (HEADER_NAME_I)");
-
-    let t = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("YXAtYXV0aC10b2tlbg==")
-            .expect("Failed to decode base64 HEADER_NAME_T"),
-    )
-    .expect("Invalid base64 string (HEADER_NAME_T)");
-
-    let s = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("YXAtYXV0aC1zZWNyZXQ=")
-            .expect("Failed to decode base64 HEADER_NAME_S"),
-    )
-    .expect("Invalid base64 string (HEADER_NAME_S)");
-
-    let n = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("YXAtYXV0aC1ub25jZQ==")
-            .expect("Failed to decode base64 HEADER_NAME_N"),
-    )
-    .expect("Invalid base64 string (HEADER_NAME_N)");
+    let i = comptime_b64!("YXAtYXV0aC1pZGVudGlmaWVy");
+    let t = comptime_b64!("YXAtYXV0aC10b2tlbg==");
+    let s = comptime_b64!("YXAtYXV0aC1zZWNyZXQ=");
+    let n = comptime_b64!("YXAtYXV0aC1ub25jZQ==");
 
     HeaderMapping { i, t, s, n }
 });
 
 /// The login route used for login requests.
-pub(crate) static MASKED_LOGIN: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("bG9naW4vYWxwaGFwb2xpcy5qc29u")
-            .expect("Failed to decode base64 MASKED_LOGIN"),
-    )
-    .expect("Invalid base64 string (MASKED_LOGIN)")
-});
+pub(crate) const MASKED_LOGIN: &str = comptime_b64!("bG9naW4vYWxwaGFwb2xpcy5qc29u");
 
 /// Returns the constants for the given device type.
 ///

--- a/tosho_amap/src/lib.rs
+++ b/tosho_amap/src/lib.rs
@@ -77,7 +77,7 @@ impl AMClient {
         );
         headers.insert(
             reqwest::header::HOST,
-            reqwest::header::HeaderValue::from_static(&API_HOST),
+            reqwest::header::HeaderValue::from_static(API_HOST),
         );
         let constants = get_constants(1);
         headers.insert(
@@ -132,7 +132,7 @@ impl AMClient {
     where
         T: serde::de::DeserializeOwned + std::clone::Clone,
     {
-        let endpoint = format!("{}{}", &*BASE_API, endpoint);
+        let endpoint = format!("{}{}", BASE_API, endpoint);
 
         let mut cloned_json = json.clone().unwrap_or_default();
         self.apply_json_object(&mut cloned_json)?;
@@ -401,7 +401,7 @@ impl AMClient {
         let mut headers = make_header(&self.config, self.constants)?;
         headers.insert(
             "Host",
-            reqwest::header::HeaderValue::from_static(&IMAGE_HOST),
+            reqwest::header::HeaderValue::from_static(IMAGE_HOST),
         );
         headers.insert(
             "User-Agent",
@@ -443,7 +443,7 @@ impl AMClient {
         );
         headers.insert(
             reqwest::header::HOST,
-            reqwest::header::HeaderValue::from_static(&API_HOST),
+            reqwest::header::HeaderValue::from_static(API_HOST),
         );
         let constants = get_constants(1);
         headers.insert(
@@ -478,7 +478,7 @@ impl AMClient {
         let req = session
             .request(
                 reqwest::Method::POST,
-                format!("{}/iap/remainder.json", &*BASE_API),
+                format!("{}/iap/remainder.json", BASE_API),
             )
             .headers(make_header(&temp_config, android_c)?)
             .json(&json_body)
@@ -513,7 +513,7 @@ impl AMClient {
         let req = session
             .request(
                 reqwest::Method::POST,
-                format!("{}/{}", &*BASE_API, &*MASKED_LOGIN),
+                format!("{}/{}", BASE_API, MASKED_LOGIN),
             )
             .headers(make_header(&temp_config, android_c)?)
             .json(&json_body_login)
@@ -544,7 +544,7 @@ impl AMClient {
         let req = session
             .request(
                 reqwest::Method::POST,
-                format!("{}/iap/remainder.json", &*BASE_API),
+                format!("{}/iap/remainder.json", BASE_API),
             )
             .headers(make_header(&temp_config, android_c)?)
             .json(&json_body_session)
@@ -600,21 +600,21 @@ fn make_header(
     let mut req_headers = reqwest::header::HeaderMap::new();
 
     let current_unix = chrono::Utc::now().timestamp();
-    let av = format!("{}/{}", &*APP_NAME, constants.version);
+    let av = format!("{}/{}", APP_NAME, constants.version);
     let formulae = format!("{}{}{}", config.token(), current_unix, av);
 
     let formulae_hashed = <Sha256 as Digest>::digest(formulae.as_bytes());
     let formulae_hashed = format!("{formulae_hashed:x}");
 
     req_headers.insert(
-        HEADER_NAMES.s.as_str(),
+        HEADER_NAMES.s,
         formulae_hashed
             .parse()
             .map_err(|e| make_error!("Failed to parse custom hash into header value: {}", e))?,
     );
     if !config.identifier().is_empty() {
         req_headers.insert(
-            HEADER_NAMES.i.as_str(),
+            HEADER_NAMES.i,
             config
                 .identifier()
                 .parse()
@@ -622,7 +622,7 @@ fn make_header(
         );
     }
     req_headers.insert(
-        HEADER_NAMES.n.as_str(),
+        HEADER_NAMES.n,
         current_unix.to_string().parse().map_err(|e| {
             make_error!(
                 "Failed to parse current unix timestamp into header value: {}",
@@ -631,7 +631,7 @@ fn make_header(
         })?,
     );
     req_headers.insert(
-        HEADER_NAMES.t.as_str(),
+        HEADER_NAMES.t,
         config
             .token()
             .parse()

--- a/tosho_kmkc/Cargo.toml
+++ b/tosho_kmkc/Cargo.toml
@@ -27,7 +27,6 @@ serde_json.workspace = true
 reqwest = { workspace = true, features = ["cookies"] }
 reqwest_cookie_store.workspace = true
 
-base64.workspace = true
 chrono.workspace = true
 time.workspace = true
 sha2.workspace = true

--- a/tosho_kmkc/src/config.rs
+++ b/tosho_kmkc/src/config.rs
@@ -129,7 +129,7 @@ impl KMConfigWebKV {
         let name: String = name.into();
 
         Ok(RawCookie::build((name.clone(), binding))
-            .domain(&*BASE_HOST)
+            .domain(BASE_HOST)
             .secure(true)
             .http_only(false)
             .path("/")
@@ -221,8 +221,8 @@ impl TryFrom<KMConfigWeb> for reqwest_cookie_store::CookieStore {
 
     fn try_from(value: KMConfigWeb) -> Result<Self, Self::Error> {
         let mut store = reqwest_cookie_store::CookieStore::default();
-        let base_host_url = Url::parse(&format!("https://{}", &*BASE_HOST))
-            .map_err(|e| make_error!("Failed to parse base host url of {}: {}", &*BASE_HOST, e))?;
+        let base_host_url = Url::parse(&format!("https://{}", BASE_HOST))
+            .map_err(|e| make_error!("Failed to parse base host url of {}: {}", BASE_HOST, e))?;
 
         let birthday_cookie = value.birthday.try_to_cookie("birthday")?;
         let tos_adult_cookie = value.tos_adult.try_to_cookie("terms_of_service_adult")?;
@@ -261,7 +261,7 @@ impl TryFrom<KMConfigWeb> for reqwest_cookie_store::CookieStore {
 
         if !value.uwt.is_empty() {
             let uwt = RawCookie::build(("uwt", value.uwt))
-                .domain(&*BASE_HOST)
+                .domain(BASE_HOST)
                 .secure(true)
                 .http_only(true)
                 .path("/")

--- a/tosho_kmkc/src/constants.rs
+++ b/tosho_kmkc/src/constants.rs
@@ -10,15 +10,17 @@
 
 use std::sync::LazyLock;
 
-use base64::{Engine as _, engine::general_purpose};
+use tosho_macros::comptime_b64;
+
+const HASH_HEADER_MOBILE: &str = comptime_b64!("eC1tZ3BrLWhhc2g=");
 
 /// A struct containing constants used in the library.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Constants {
     /// The user agent string used for API requests.
-    pub(crate) ua: String,
+    pub(crate) ua: &'static str,
     /// The user agent string used for image requests.
-    pub(crate) image_ua: String,
+    pub(crate) image_ua: &'static str,
     /// The platform string used for API requests.
     pub(crate) platform: &'static str,
     /// The version string used for API requests.
@@ -26,7 +28,7 @@ pub struct Constants {
     /// Display version?
     pub(crate) display_version: Option<&'static str>,
     /// The hash header used for API requests.
-    pub(crate) hash: String,
+    pub(crate) hash: &'static str,
 }
 
 /// A ranking tab for KM.
@@ -47,44 +49,22 @@ impl RankingTab {
 }
 
 /// The constants used for Android devices.
-pub static ANDROID_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
-    let hash_header = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("eC1tZ3BrLWhhc2g=")
-            .expect("Failed to decode base64 ANDROID_HASH_HEADER"),
-    )
-    .expect("Invalid base64 string");
-
-    Constants {
-        ua: "okhttp/4.9.3".to_string(),
-        image_ua: "okhttp/4.9.3".to_string(),
-        platform: "2",
-        version: "6.1.0",
-        display_version: Some("2.1.5"),
-        hash: hash_header,
-    }
+pub static ANDROID_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| Constants {
+    ua: "okhttp/4.9.3",
+    image_ua: "okhttp/4.9.3",
+    platform: "2",
+    version: "6.1.0",
+    display_version: Some("2.1.5"),
+    hash: HASH_HEADER_MOBILE,
 });
 /// The constants used for iOS devices.
 pub static APPLE_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
-    let hash_header = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("eC1tZ3BrLWhhc2g=")
-            .expect("Failed to decode base64 IOS_HASH_HEADER"),
-    )
-    .expect("Invalid base64 string");
+    let hash_header = comptime_b64!("eC1tZ3BrLWhhc2g=");
 
-    let api_ua = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("bWFnZTItZW4vMS4yLjUgKGNvbS5rb2RhbnNoYS5rbWFuZ2E7IGJ1aWxkOjEuMi41OyBpT1MgMTcuMS4yKSBBbGFtb2ZpcmUvMS4yLjU=")
-            .expect("Failed to decode base64 IOS_API_UA"),
-    )
-    .expect("Invalid base64 string");
-    let image_ua = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("bWFnZTItZW4vMS4yLjUgQ0ZOZXR3b3JrLzE0ODUgRGFyd2luLzIzLjEuMA==")
-            .expect("Failed to decode base64 IOS_IMAGE_UA"),
-    )
-    .expect("Invalid base64 string");
+    let api_ua = comptime_b64!(
+        "bWFnZTItZW4vMS4yLjUgKGNvbS5rb2RhbnNoYS5rbWFuZ2E7IGJ1aWxkOjEuMi41OyBpT1MgMTcuMS4yKSBBbGFtb2ZpcmUvMS4yLjU="
+    );
+    let image_ua = comptime_b64!("bWFnZTItZW4vMS4yLjUgQ0ZOZXR3b3JrLzE0ODUgRGFyd2luLzIzLjEuMA==");
 
     Constants {
         ua: api_ua,
@@ -97,17 +77,11 @@ pub static APPLE_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
 });
 /// The constants used for web devices.
 pub static WEB_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
-    let hash_header = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("WC1LbWFuZ2EtSGFzaA==")
-            .expect("Failed to decode base64 WEB_HASH_HEADER"),
-    )
-    .expect("Invalid base64 string");
-
-    let chrome_ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36".to_string();
+    let hash_header = comptime_b64!("WC1LbWFuZ2EtSGFzaA==");
+    let chrome_ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36";
 
     Constants {
-        ua: chrome_ua.clone(),
+        ua: chrome_ua,
         image_ua: chrome_ua,
         platform: "3",
         version: "6.0.0",
@@ -117,51 +91,16 @@ pub static WEB_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
 });
 
 /// The base API used for overall requests.
-pub static BASE_API: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aHR0cHM6Ly9hcGkua21hbmdhLmtvZGFuc2hhLmNvbQ==")
-            .expect("Failed to decode base64 BASE_API"),
-    )
-    .expect("Invalid base64 string (BASE_API)")
-});
+pub const BASE_API: &str = comptime_b64!("aHR0cHM6Ly9hcGkua21hbmdhLmtvZGFuc2hhLmNvbQ==");
 /// The base image URL used for image requests.
-pub static BASE_IMG: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aHR0cHM6Ly9jZG4ua21hbmdhLmtvZGFuc2hhLmNvbQ==")
-            .expect("Failed to decode base64 BASE_IMG"),
-    )
-    .expect("Invalid base64 string (BASE_IMG)")
-});
+pub const BASE_IMG: &str = comptime_b64!("aHR0cHM6Ly9jZG4ua21hbmdhLmtvZGFuc2hhLmNvbQ==");
 
 /// The base host used for overall requests.
-pub static BASE_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("a21hbmdhLmtvZGFuc2hhLmNvbQ==")
-            .expect("Failed to decode base64 BASE_HOST"),
-    )
-    .expect("Invalid base64 string (BASE_HOST)")
-});
+pub const BASE_HOST: &str = comptime_b64!("a21hbmdhLmtvZGFuc2hhLmNvbQ==");
 /// The API host used for API requests.
-pub static API_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("YXBpLmttYW5nYS5rb2RhbnNoYS5jb20=")
-            .expect("Failed to decode base64 API_HOST"),
-    )
-    .expect("Invalid base64 string (API_HOST)")
-});
+pub const API_HOST: &str = comptime_b64!("YXBpLmttYW5nYS5rb2RhbnNoYS5jb20=");
 /// The image host used for image requests.
-pub static IMAGE_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("Y2RuLmttYW5nYS5rb2RhbnNoYS5jb20=")
-            .expect("Failed to decode base64 IMAGE_HOST"),
-    )
-    .expect("Invalid base64 string (IMAGE_HOST)")
-});
+pub const IMAGE_HOST: &str = comptime_b64!("Y2RuLmttYW5nYS5rb2RhbnNoYS5jb20=");
 
 /// The ranking tabs used for the ranking endpoint.
 ///

--- a/tosho_kmkc/src/lib.rs
+++ b/tosho_kmkc/src/lib.rs
@@ -93,13 +93,13 @@ impl KMClient {
         );
         headers.insert(
             reqwest::header::HOST,
-            reqwest::header::HeaderValue::from_static(&API_HOST),
+            reqwest::header::HeaderValue::from_static(API_HOST),
         );
         match config {
             KMConfig::Web(web) => {
                 headers.insert(
                     reqwest::header::USER_AGENT,
-                    reqwest::header::HeaderValue::from_static(&WEB_CONSTANTS.ua),
+                    reqwest::header::HeaderValue::from_static(WEB_CONSTANTS.ua),
                 );
 
                 let cookie_store = CookieStoreMutex::try_from(web.clone())?;
@@ -131,7 +131,7 @@ impl KMClient {
                 let consts = get_constants(mobile.platform() as u8);
                 headers.insert(
                     reqwest::header::USER_AGENT,
-                    reqwest::header::HeaderValue::from_static(&consts.ua),
+                    reqwest::header::HeaderValue::from_static(consts.ua),
                 );
 
                 let cookie_store = CookieStoreMutex::default();
@@ -207,12 +207,11 @@ impl KMClient {
     where
         T: serde::de::DeserializeOwned,
     {
-        let endpoint = format!("{}{}", &*BASE_API, endpoint);
+        let endpoint = format!("{}{}", BASE_API, endpoint);
         let mut extend_headers = match headers {
             Some(headers) => headers,
             None => reqwest::header::HeaderMap::new(),
         };
-        let hash_header = self.constants.hash.as_str();
 
         let hash_value = match data.clone() {
             Some(mut data) => self.format_request(&mut data)?,
@@ -227,13 +226,13 @@ impl KMClient {
         let empty_hash = self.format_request(&mut empty_params)?;
 
         empty_headers.insert(
-            hash_header,
+            self.constants.hash,
             empty_hash
                 .parse()
                 .map_err(|e| make_error!("Failed to parse empty hash header: {}", e))?,
         );
         extend_headers.insert(
-            hash_header,
+            self.constants.hash,
             hash_value
                 .parse()
                 .map_err(|e| make_error!("Failed to parse value hash header: {}", e))?,
@@ -756,11 +755,11 @@ impl KMClient {
                 let mut headers = reqwest::header::HeaderMap::new();
                 headers.insert(
                     reqwest::header::USER_AGENT,
-                    reqwest::header::HeaderValue::from_static(&self.constants.image_ua),
+                    reqwest::header::HeaderValue::from_static(self.constants.image_ua),
                 );
                 headers.insert(
                     reqwest::header::HOST,
-                    reqwest::header::HeaderValue::from_static(&IMAGE_HOST),
+                    reqwest::header::HeaderValue::from_static(IMAGE_HOST),
                 );
                 headers
             })
@@ -821,11 +820,11 @@ impl KMClient {
         );
         headers.insert(
             reqwest::header::HOST,
-            reqwest::header::HeaderValue::from_static(&API_HOST),
+            reqwest::header::HeaderValue::from_static(API_HOST),
         );
         headers.insert(
             reqwest::header::USER_AGENT,
-            reqwest::header::HeaderValue::from_static(&WEB_CONSTANTS.ua),
+            reqwest::header::HeaderValue::from_static(WEB_CONSTANTS.ua),
         );
 
         let default_web = KMConfigWeb::default();
@@ -857,13 +856,13 @@ impl KMClient {
             reqwest::header::HeaderValue::from_static("application/x-www-form-urlencoded"),
         );
         extend_headers.insert(
-            WEB_CONSTANTS.hash.as_str(),
+            WEB_CONSTANTS.hash,
             req_hash
                 .parse()
                 .map_err(|e| make_error!("Failed to parse hash header: {}", e))?,
         );
         let response = client
-            .post(format!("{}/web/user/login", &*BASE_API))
+            .post(format!("{}/web/user/login", BASE_API))
             .form(&req_data)
             .headers(extend_headers)
             .send()

--- a/tosho_macros/Cargo.toml
+++ b/tosho_macros/Cargo.toml
@@ -16,6 +16,8 @@ syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
 
+base64.workspace = true
+
 [dev-dependencies]
 serde.workspace = true
 prost.workspace = true

--- a/tosho_macros/src/common.rs
+++ b/tosho_macros/src/common.rs
@@ -1,3 +1,4 @@
+use base64::Engine as _;
 use syn::Attribute;
 
 pub(crate) fn get_field_comment(attrs: &[Attribute]) -> Option<String> {
@@ -35,4 +36,44 @@ pub(crate) fn get_field_comment(attrs: &[Attribute]) -> Option<String> {
     } else {
         Some(joined_cmt)
     }
+}
+
+pub(crate) struct CompTimeBase64Input {
+    // This should only have a string literal
+    base64_str: syn::LitStr,
+}
+
+impl syn::parse::Parse for CompTimeBase64Input {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let base64_str: syn::LitStr = input.parse()?;
+
+        Ok(CompTimeBase64Input { base64_str })
+    }
+}
+
+pub(crate) fn impl_base64_decode(input: &CompTimeBase64Input) -> proc_macro::TokenStream {
+    let base64_str = &input.base64_str;
+    let base64_as_str = base64_str.value();
+    let decoded_bytes = match base64::engine::general_purpose::STANDARD.decode(base64_as_str) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return proc_macro::TokenStream::from(
+                syn::Error::new_spanned(base64_str, "Invalid base64 provided").to_compile_error(),
+            );
+        }
+    };
+
+    let decoded_string = match String::from_utf8(decoded_bytes) {
+        Ok(string) => string,
+        Err(_) => {
+            return proc_macro::TokenStream::from(
+                syn::Error::new_spanned(base64_str, "Base64 is not valid UTF-8").to_compile_error(),
+            );
+        }
+    };
+
+    let generate = quote::quote! {
+        #decoded_string
+    };
+    generate.into()
 }

--- a/tosho_macros/src/lib.rs
+++ b/tosho_macros/src/lib.rs
@@ -206,6 +206,21 @@ pub fn enum_error(item: TokenStream) -> TokenStream {
     enums::impl_enum_error(&input)
 }
 
+/// Create a decoded base64 string at compile time.
+///
+/// # Example
+/// ```rust
+/// # use tosho_macros::base64_decode;
+///
+/// let decoded = base64_decode!("SGVsbG8sIFdvcmxkIQ==");
+/// assert_eq!(decoded, "Hello, World!");
+/// ```
+#[proc_macro]
+pub fn comptime_b64(item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as common::CompTimeBase64Input);
+    common::impl_base64_decode(&input)
+}
+
 /// Derive the `AutoGetter` macro for a struct
 ///
 /// Automatically expand each field into their own getter function for all private field.

--- a/tosho_mplus/Cargo.toml
+++ b/tosho_mplus/Cargo.toml
@@ -22,7 +22,6 @@ prost.workspace = true
 
 reqwest.workspace = true
 
-base64.workspace = true
 chrono.workspace = true
 
 tosho-macros = { path = "../tosho_macros", version = "0.5" }

--- a/tosho_mplus/src/constants.rs
+++ b/tosho_mplus/src/constants.rs
@@ -10,7 +10,7 @@
 
 use std::sync::LazyLock;
 
-use base64::{Engine as _, engine::general_purpose};
+use tosho_macros::comptime_b64;
 
 /// A struct containing constants used in the library.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -39,51 +39,16 @@ pub static ANDROID_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
 });
 
 /// The base API used for overall requests.
-pub static BASE_API: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aHR0cHM6Ly9qdW1wZy1hcGkudG9reW8tY2RuLmNvbS9hcGk=")
-            .expect("Failed to decode base64 BASE_API"),
-    )
-    .expect("Invalid base64 string (BASE_API)")
-});
+pub const BASE_API: &str = comptime_b64!("aHR0cHM6Ly9qdW1wZy1hcGkudG9reW8tY2RuLmNvbS9hcGk=");
 /// The base image URL used for image requests.
-pub static BASE_IMG: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aHR0cHM6Ly9qdW1wZy1hc3NldHMudG9reW8tY2RuLmNvbQ==")
-            .expect("Failed to decode base64 BASE_IMG"),
-    )
-    .expect("Invalid base64 string (BASE_IMG)")
-});
+pub const BASE_IMG: &str = comptime_b64!("aHR0cHM6Ly9qdW1wZy1hc3NldHMudG9reW8tY2RuLmNvbQ==");
 
 /// The base host used for overall requests.
-pub static BASE_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("bWFuZ2FwbHVzLnNodWVpc2hhLmNvLmpw")
-            .expect("Failed to decode base64 BASE_HOST"),
-    )
-    .expect("Invalid base64 string (BASE_HOST)")
-});
+pub const BASE_HOST: &str = comptime_b64!("bWFuZ2FwbHVzLnNodWVpc2hhLmNvLmpw");
 /// The API host used for API requests.
-pub static API_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("anVtcGctYXBpLnRva3lvLWNkbi5jb20=")
-            .expect("Failed to decode base64 API_HOST"),
-    )
-    .expect("Invalid base64 string (API_HOST)")
-});
+pub const API_HOST: &str = comptime_b64!("anVtcGctYXBpLnRva3lvLWNkbi5jb20=");
 /// The image host used for image requests.
-pub static IMAGE_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("anVtcGctYXNzZXRzLnRva3lvLWNkbi5jb20=")
-            .expect("Failed to decode base64 IMAGE_HOST"),
-    )
-    .expect("Invalid base64 string (IMAGE_HOST)")
-});
+pub const IMAGE_HOST: &str = comptime_b64!("anVtcGctYXNzZXRzLnRva3lvLWNkbi5jb20=");
 
 /// Returns the constants for the given device type.
 ///

--- a/tosho_mplus/src/lib.rs
+++ b/tosho_mplus/src/lib.rs
@@ -90,7 +90,7 @@ impl MPClient {
         proxy: Option<reqwest::Proxy>,
     ) -> ToshoResult<Self> {
         let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert("Host", reqwest::header::HeaderValue::from_static(&API_HOST));
+        headers.insert("Host", reqwest::header::HeaderValue::from_static(API_HOST));
         headers.insert(
             "User-Agent",
             reqwest::header::HeaderValue::from_static(&constants.api_ua),
@@ -146,10 +146,10 @@ impl MPClient {
 
     fn build_url(&self, path: &str) -> String {
         if path.starts_with('/') {
-            return format!("{}{}", *BASE_API, path);
+            return format!("{}{}", BASE_API, path);
         }
 
-        format!("{}/{}", *BASE_API, path)
+        format!("{}/{}", BASE_API, path)
     }
 
     fn empty_params(&self, with_lang: bool) -> Vec<(String, String)> {
@@ -546,7 +546,7 @@ impl MPClient {
                 let mut headers = reqwest::header::HeaderMap::new();
                 headers.insert(
                     "Host",
-                    reqwest::header::HeaderValue::from_static(&IMAGE_HOST),
+                    reqwest::header::HeaderValue::from_static(IMAGE_HOST),
                 );
                 headers.insert(
                     "User-Agent",

--- a/tosho_musq/Cargo.toml
+++ b/tosho_musq/Cargo.toml
@@ -28,7 +28,6 @@ prost.workspace = true
 
 reqwest.workspace = true
 
-base64.workspace = true
 chrono.workspace = true
 
 aes = { workspace = true, optional = true }

--- a/tosho_musq/src/constants.rs
+++ b/tosho_musq/src/constants.rs
@@ -10,7 +10,7 @@
 
 use std::sync::LazyLock;
 
-use base64::{Engine as _, engine::general_purpose};
+use tosho_macros::comptime_b64;
 
 /// A struct containing constants used in the library.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -38,24 +38,9 @@ pub static ANDROID_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
 });
 /// The constants used for Apple/iOS devices.
 pub static APPLE_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
-    let ios_app = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("Y29tLnNxdWFyZS1lbml4Lk1hbmdhVVB3")
-            .expect("Failed to decode base64 IOS_APP"),
-    )
-    .expect("Invalid base64 string (IOS_APP)");
-    let ios_app_pre = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("R2xlbndvb2RfUHJvZA==")
-            .expect("Failed to decode base64 IOS_APP_PRE"),
-    )
-    .expect("Invalid base64 string (IOS_APP_PRE)");
-    let ios_app_post = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("QWxhbW9maXJlLzUuNy4x")
-            .expect("Failed to decode base64 IOS_APP_POST"),
-    )
-    .expect("Invalid base64 string (IOS_APP_POST)");
+    let ios_app = comptime_b64!("Y29tLnNxdWFyZS1lbml4Lk1hbmdhVVB3");
+    let ios_app_pre = comptime_b64!("R2xlbndvb2RfUHJvZA==");
+    let ios_app_post = comptime_b64!("QWxhbW9maXJlLzUuNy4x");
 
     let ios_app_ver = "2.6.1";
     let ios_app_build = "202411251121";
@@ -80,51 +65,16 @@ pub static WEB_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| Constants {
 });
 
 /// The base API used for overall requests.
-pub static BASE_API: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aHR0cHM6Ly9nbG9iYWwtYXBpLm1hbmdhLXVwLmNvbS9hcGk=")
-            .expect("Failed to decode base64 BASE_API"),
-    )
-    .expect("Invalid base64 string (BASE_API)")
-});
+pub const BASE_API: &str = comptime_b64!("aHR0cHM6Ly9nbG9iYWwtYXBpLm1hbmdhLXVwLmNvbS9hcGk=");
 /// The base image URL used for image requests.
-pub static BASE_IMG: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aHR0cHM6Ly9nbG9iYWwtaW1nLm1hbmdhLXVwLmNvbQ==")
-            .expect("Failed to decode base64 BASE_IMG"),
-    )
-    .expect("Invalid base64 string (BASE_IMG)")
-});
+pub const BASE_IMG: &str = comptime_b64!("aHR0cHM6Ly9nbG9iYWwtaW1nLm1hbmdhLXVwLmNvbQ==");
 
 /// The base host used for overall requests.
-pub static BASE_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("Z2xvYmFsLm1hbmdhLXVwLmNvbQ==")
-            .expect("Failed to decode base64 BASE_HOST"),
-    )
-    .expect("Invalid base64 string (BASE_HOST)")
-});
+pub const BASE_HOST: &str = comptime_b64!("Z2xvYmFsLm1hbmdhLXVwLmNvbQ==");
 /// The API host used for API requests.
-pub static API_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("Z2xvYmFsLWFwaS5tYW5nYS11cC5jb20=")
-            .expect("Failed to decode base64 API_HOST"),
-    )
-    .expect("Invalid base64 string (API_HOST)")
-});
+pub const API_HOST: &str = comptime_b64!("Z2xvYmFsLWFwaS5tYW5nYS11cC5jb20=");
 /// The image host used for image requests.
-pub static IMAGE_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("Z2xvYmFsLWltZy5tYW5nYS11cC5jb20=")
-            .expect("Failed to decode base64 IMAGE_HOST"),
-    )
-    .expect("Invalid base64 string (IMAGE_HOST)")
-});
+pub const IMAGE_HOST: &str = comptime_b64!("Z2xvYmFsLWltZy5tYW5nYS11cC5jb20=");
 
 /// Returns the constants for the given device type.
 ///

--- a/tosho_musq/src/lib.rs
+++ b/tosho_musq/src/lib.rs
@@ -71,7 +71,7 @@ impl MUClient {
         proxy: Option<reqwest::Proxy>,
     ) -> ToshoResult<Self> {
         let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert("Host", reqwest::header::HeaderValue::from_static(&API_HOST));
+        headers.insert("Host", reqwest::header::HeaderValue::from_static(API_HOST));
         headers.insert(
             "User-Agent",
             reqwest::header::HeaderValue::from_static(&constants.api_ua),
@@ -228,10 +228,10 @@ impl MUClient {
     /// Build and merge URL into a full API url
     fn build_url(&self, path: &str) -> String {
         if path.starts_with('/') {
-            return format!("{}{}", &*BASE_API, path);
+            return format!("{}{}", BASE_API, path);
         }
 
-        format!("{}/{}", &*BASE_API, path)
+        format!("{}/{}", BASE_API, path)
     }
 
     /// Create an empty params
@@ -492,10 +492,10 @@ impl MUClient {
         let url = url.as_ref();
         match ::reqwest::Url::parse(url) {
             Ok(mut parsed_url) => {
-                let valid_host = ::reqwest::Url::parse(
-                    format!("https://{}", &*IMAGE_HOST).as_str(),
-                )
-                .map_err(|e| make_error!("Failed to parse image host: {}: {}", &*IMAGE_HOST, e))?;
+                let valid_host = ::reqwest::Url::parse(format!("https://{}", IMAGE_HOST).as_str())
+                    .map_err(|e| {
+                        make_error!("Failed to parse image host: {}: {}", IMAGE_HOST, e)
+                    })?;
                 let host_name = valid_host
                     .host_str()
                     .ok_or_else(|| make_error!("Failed to get host from: {}", &valid_host))?;
@@ -503,7 +503,7 @@ impl MUClient {
                     make_error!(
                         "Failed to replace image host: {} with {}: {}",
                         url,
-                        &*IMAGE_HOST,
+                        IMAGE_HOST,
                         e
                     )
                 })?;
@@ -512,9 +512,9 @@ impl MUClient {
             }
             Err(_) => {
                 // parse url failed, assume it's a relative path
-                let full_url = format!("https://{}{}", &*IMAGE_HOST, url);
+                let full_url = format!("https://{}{}", IMAGE_HOST, url);
                 let parse_url = ::reqwest::Url::parse(full_url.as_str()).map_err(|e| {
-                    make_error!("Failed to parse image host: {}: {}", &*IMAGE_HOST, e)
+                    make_error!("Failed to parse image host: {}: {}", IMAGE_HOST, e)
                 })?;
                 Ok(parse_url)
             }
@@ -542,7 +542,7 @@ impl MUClient {
                 let mut headers = reqwest::header::HeaderMap::new();
                 headers.insert(
                     "Host",
-                    reqwest::header::HeaderValue::from_static(&IMAGE_HOST),
+                    reqwest::header::HeaderValue::from_static(IMAGE_HOST),
                 );
                 headers.insert(
                     "User-Agent",

--- a/tosho_rbean/Cargo.toml
+++ b/tosho_rbean/Cargo.toml
@@ -22,7 +22,6 @@ serde_json.workspace = true
 
 reqwest = { workspace = true, features = ["json"] }
 
-base64.workspace = true
 chrono.workspace = true
 
 tosho-macros = { path = "../tosho_macros", version = "0.5" }

--- a/tosho_rbean/src/constants.rs
+++ b/tosho_rbean/src/constants.rs
@@ -10,7 +10,7 @@
 
 use std::sync::LazyLock;
 
-use base64::{Engine as _, engine::general_purpose};
+use tosho_macros::comptime_b64;
 
 /// A struct containing constants used in the library.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,27 +20,16 @@ pub struct Constants {
     /// The user agent string used for image requests.
     pub(crate) image_ua: &'static str,
     /// Public key used for authentication.
-    pub(crate) public: String,
+    pub(crate) public: &'static str,
 }
 
 /// Token used for authentication.
-pub(crate) static TOKEN_AUTH: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("QUl6YVN5RHR5bjg0U2J1ZFptOWFoZkgwNnYtaUppV0JZWVp1c1lrDQo=")
-            .expect("Failed to decode base64 TOKEN_AUTH"),
-    )
-    .expect("Invalid base64 string (TOKEN_AUTH)")
-});
+pub(crate) const TOKEN_AUTH: &str =
+    comptime_b64!("QUl6YVN5RHR5bjg0U2J1ZFptOWFoZkgwNnYtaUppV0JZWVp1c1lr");
 
 /// The constants used for Android devices.
 pub static ANDROID_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
-    let public = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("TVA2d2J1WkF3Mm5UTTlQUVQ4R2ZGNGZz")
-            .expect("Failed to decode base64 ANDROID_PUBLIC"),
-    )
-    .expect("Invalid base64 string (ANDROID_PUBLIC)");
+    let public = comptime_b64!("TVA2d2J1WkF3Mm5UTTlQUVQ4R2ZGNGZz");
 
     Constants {
         ua: "okhttp/4.9.0",
@@ -50,61 +39,20 @@ pub static ANDROID_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
 });
 
 /// The base API used for overall requests.
-pub static BASE_API: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aHR0cHM6Ly9wcm9kdWN0aW9uLmFwaS5henVraS5jbw==")
-            .expect("Failed to decode base64 BASE_API"),
-    )
-    .expect("Invalid base64 string (BASE_API)")
-});
+pub const BASE_API: &str = comptime_b64!("aHR0cHM6Ly9wcm9kdWN0aW9uLmFwaS5henVraS5jbw==");
 /// The base image URL used for image requests.
-pub static BASE_IMG: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aHR0cHM6Ly9wcm9kdWN0aW9uLmltYWdlLWNvbnRlbnQuYXp1a2kuY28=")
-            .expect("Failed to decode base64 BASE_IMG"),
-    )
-    .expect("Invalid base64 string (BASE_IMG)")
-});
+pub const BASE_IMG: &str =
+    comptime_b64!("aHR0cHM6Ly9wcm9kdWN0aW9uLmltYWdlLWNvbnRlbnQuYXp1a2kuY28=");
 
 /// The base host used for overall requests.
-pub static BASE_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("d3d3LmF6dWtpLmNv")
-            .expect("Failed to decode base64 BASE_HOST"),
-    )
-    .expect("Invalid base64 string (BASE_HOST)")
-});
+pub const BASE_HOST: &str = comptime_b64!("d3d3LmF6dWtpLmNv");
 /// The API host used for API requests.
-pub static API_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("cHJvZHVjdGlvbi5hcGkuYXp1a2kuY28=")
-            .expect("Failed to decode base64 API_HOST"),
-    )
-    .expect("Invalid base64 string (API_HOST)")
-});
+pub const API_HOST: &str = comptime_b64!("cHJvZHVjdGlvbi5hcGkuYXp1a2kuY28=");
 /// The image host used for image requests.
-pub static IMAGE_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("cHJvZHVjdGlvbi5pbWFnZS1jb250ZW50LmF6dWtpLmNv")
-            .expect("Failed to decode base64 IMAGE_HOST"),
-    )
-    .expect("Invalid base64 string (IMAGE_HOST)")
-});
+pub const IMAGE_HOST: &str = comptime_b64!("cHJvZHVjdGlvbi5pbWFnZS1jb250ZW50LmF6dWtpLmNv");
 
 /// The X-DRM-HEADER used for API requests.
-pub(crate) static X_DRM_HEADER: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("WC1BWlVLSS1EUk0=")
-            .expect("Failed to decode base64 X_DRM_HEADER"),
-    )
-    .expect("Invalid base64 string (X_DRM_HEADER)")
-});
+pub(crate) const X_DRM_HEADER: &str = comptime_b64!("WC1BWlVLSS1EUk0=");
 
 /// Returns the constants for the given device type.
 ///

--- a/tosho_rbean/src/lib.rs
+++ b/tosho_rbean/src/lib.rs
@@ -79,11 +79,11 @@ impl RBClient {
         );
         headers.insert(
             reqwest::header::HOST,
-            reqwest::header::HeaderValue::from_static(&API_HOST),
+            reqwest::header::HeaderValue::from_static(API_HOST),
         );
         headers.insert(
             "public",
-            reqwest::header::HeaderValue::from_static(&constants.public),
+            reqwest::header::HeaderValue::from_static(constants.public),
         );
         headers.insert(
             "x-user-token",
@@ -196,7 +196,7 @@ impl RBClient {
     {
         self.refresh_token().await?;
 
-        let endpoint = format!("{}{}", &*BASE_API, url);
+        let endpoint = format!("{}{}", BASE_API, url);
 
         let request = match json_body {
             Some(json_body) => self.inner.request(method, endpoint).json(&json_body),
@@ -418,7 +418,7 @@ impl RBClient {
                 );
                 headers.insert(
                     reqwest::header::HOST,
-                    reqwest::header::HeaderValue::from_static(&IMAGE_HOST),
+                    reqwest::header::HeaderValue::from_static(IMAGE_HOST),
                 );
                 headers
             })
@@ -429,8 +429,7 @@ impl RBClient {
             Err(ToshoError::from(res.status()))
         } else {
             // Check if we need to decrypt
-            let header_name = &crate::constants::X_DRM_HEADER;
-            let x_drm = res.headers().get(header_name.as_str());
+            let x_drm = res.headers().get(crate::constants::X_DRM_HEADER);
             let is_drm = match x_drm {
                 Some(x_drm) => x_drm == "true",
                 None => false,
@@ -471,7 +470,7 @@ impl RBClient {
                 );
                 headers.insert(
                     reqwest::header::HOST,
-                    reqwest::header::HeaderValue::from_static(&IMAGE_HOST),
+                    reqwest::header::HeaderValue::from_static(IMAGE_HOST),
                 );
                 headers
             })
@@ -602,7 +601,7 @@ impl RBClient {
 
         // Step 4: Auth with 小豆
         let request = client
-            .get(format!("{}/user/v0", &*BASE_API))
+            .get(format!("{}/user/v0", BASE_API))
             .headers({
                 let mut headers = reqwest::header::HeaderMap::new();
                 headers.insert(
@@ -611,7 +610,7 @@ impl RBClient {
                 );
                 headers.insert(
                     "public",
-                    reqwest::header::HeaderValue::from_static(&constants.public),
+                    reqwest::header::HeaderValue::from_static(constants.public),
                 );
                 headers.insert(
                     "x-user-token",

--- a/tosho_rbean/src/models/image.rs
+++ b/tosho_rbean/src/models/image.rs
@@ -71,7 +71,7 @@ impl ImageSource {
 
 impl PartialOrd for ImageSource {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.height.cmp(&other.height))
+        Some(self.cmp(other))
     }
 
     fn lt(&self, other: &Self) -> bool {

--- a/tosho_sjv/Cargo.toml
+++ b/tosho_sjv/Cargo.toml
@@ -26,7 +26,6 @@ serde_json.workspace = true
 
 reqwest = { workspace = true, features = ["json"] }
 
-base64.workspace = true
 chrono.workspace = true
 
 image.workspace = true
@@ -34,3 +33,6 @@ kamadak-exif.workspace = true
 
 tosho-macros = { path = "../tosho_macros", version = "0.5" }
 tosho-common = { path = "../tosho_common", version = "=0.2.0", features = ["serde", "image", "id-gen"] }
+
+[dev-dependencies]
+base64.workspace = true

--- a/tosho_sjv/src/constants.rs
+++ b/tosho_sjv/src/constants.rs
@@ -10,7 +10,7 @@
 
 use std::sync::LazyLock;
 
-use base64::{Engine as _, engine::general_purpose};
+use tosho_macros::comptime_b64;
 
 /// A struct containing constants used in the library.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,15 +18,15 @@ pub struct Constants {
     /// The user agent string used for requests.
     pub(crate) ua: &'static str,
     /// The app name used for Manga requests
-    pub(crate) vm_name: String,
+    pub(crate) vm_name: &'static str,
     /// The app name used for Jump requests
-    pub(crate) sj_name: String,
+    pub(crate) sj_name: &'static str,
     /// The app version string used for API requests.
     pub(crate) app_ver: &'static str,
     /// Device ID used for requests
     pub(crate) device_id: &'static str,
     /// Version body name used for requests
-    pub(crate) version_body: Option<String>,
+    pub(crate) version_body: Option<&'static str>,
 }
 
 /// App ID for VM
@@ -38,26 +38,9 @@ pub const LIB_VERSION: &str = "9";
 
 /// The constants used for Android devices.
 pub static ANDROID_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
-    let vm_android_name = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("Y29tLnZpem1hbmdhLmFuZHJvaWQ=")
-            .expect("Failed to decode base64 VM_ANDROID_NAME"),
-    )
-    .expect("Invalid base64 string (VM_ANDROID_NAME)");
-    let sj_android_name = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("Y29tLnZpei53c2ouYW5kcm9pZA==")
-            .expect("Failed to decode base64 SJ_ANDROID_NAME"),
-    )
-    .expect("Invalid base64 string (SJ_ANDROID_NAME)");
-    let android_version_body: String = {
-        String::from_utf8(
-            general_purpose::STANDARD
-                .decode("YW5kcm9pZF9hcHBfdmVyc2lvbl9jb2Rl")
-                .expect("Failed to decode base64 ANDROID_VERSION_BODY"),
-        )
-        .expect("Invalid base64 string (ANDROID_VERSION_BODY)")
-    };
+    let vm_android_name = comptime_b64!("Y29tLnZpem1hbmdhLmFuZHJvaWQ=");
+    let sj_android_name = comptime_b64!("Y29tLnZpei53c2ouYW5kcm9pZA==");
+    let android_version_body = comptime_b64!("YW5kcm9pZF9hcHBfdmVyc2lvbl9jb2Rl");
 
     Constants {
         ua: "Dalvik/2.1.0 (Linux; U; Android 12; SM-G935F Build/SQ3A.220705.004)",
@@ -70,18 +53,8 @@ pub static ANDROID_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
 });
 /// The constants used for Apple devices.
 pub static APPLE_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
-    let vm_apple_name = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("Y29tLnZpem1hbmdhLmFwcGxl")
-            .expect("Failed to decode base64 VM_APPLE_NAME"),
-    )
-    .expect("Invalid base64 string (VM_APPLE_NAME)");
-    let sj_apple_name = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("Y29tLnZpei53c2ouYXBwbGU=")
-            .expect("Failed to decode base64 SJ_APPLE_NAME"),
-    )
-    .expect("Invalid base64 string (SJ_APPLE_NAME)");
+    let vm_apple_name = comptime_b64!("Y29tLnZpem1hbmdhLmFwcGxl");
+    let sj_apple_name = comptime_b64!("Y29tLnZpei53c2ouYXBwbGU=");
 
     Constants {
         ua: "Alamofire/5.7.1/202307211728 CFNetwork/1410.0.3 Darwin/22.6.0",
@@ -95,16 +68,11 @@ pub static APPLE_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
 });
 /// The constants used for Web devices.
 pub static WEB_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
-    let common_web_name = String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aHR0cHM6Ly92aXouY29t")
-            .expect("Failed to decode base64 COMMON_WEB_NAME"),
-    )
-    .expect("Invalid base64 string (COMMON_WEB_NAME)");
+    let common_web_name = comptime_b64!("aHR0cHM6Ly92aXouY29t");
 
     Constants {
         ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0",
-        vm_name: common_web_name.clone(),
+        vm_name: common_web_name,
         sj_name: common_web_name,
         app_ver: "180",
         device_id: "3",
@@ -113,81 +81,25 @@ pub static WEB_CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
 });
 
 /// The base API used for overall requests.
-pub static BASE_API: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("aHR0cHM6Ly9hcGkudml6LmNvbQ==")
-            .expect("Failed to decode base64 BASE_API"),
-    )
-    .expect("Invalid base64 string (BASE_API)")
-});
+pub const BASE_API: &str = comptime_b64!("aHR0cHM6Ly9hcGkudml6LmNvbQ==");
 
 /// The base host used for overall requests.
-pub static BASE_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("dml6LmNvbQ==")
-            .expect("Failed to decode base64 BASE_HOST"),
-    )
-    .expect("Invalid base64 string (BASE_HOST)")
-});
+pub const BASE_HOST: &str = comptime_b64!("dml6LmNvbQ==");
 /// The API host used for API requests.
-pub static API_HOST: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("YXBpLnZpei5jb20=")
-            .expect("Failed to decode base64 API_HOST"),
-    )
-    .expect("Invalid base64 string (API_HOST)")
-});
+pub const API_HOST: &str = comptime_b64!("YXBpLnZpei5jb20=");
 
 /// The header name for the one piece reference.
-pub(crate) static HEADER_PIECE: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("eC1kZXZpbC1mcnVpdA==")
-            .expect("Failed to decode base64 HEADER_PIECE"),
-    )
-    .expect("Invalid base64 string (HEADER_PIECE)")
-});
+pub(crate) const HEADER_PIECE: &str = comptime_b64!("eC1kZXZpbC1mcnVpdA==");
 /// The header value for the one piece reference.
-pub(crate) static VALUE_PIECE: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("ZmxhbWUtZmxhbWUgZnJ1aXRz")
-            .expect("Failed to decode base64 VALUE_PIECE"),
-    )
-    .expect("Invalid base64 string (VALUE_PIECE)")
-});
+pub(crate) const VALUE_PIECE: &str = comptime_b64!("ZmxhbWUtZmxhbWUgZnJ1aXRz");
 
 /// Data name for specific app ID
-pub(crate) static DATA_APP_ID: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("dml6X2FwcF9pZA==")
-            .expect("Failed to decode base64 DATA_APP_ID"),
-    )
-    .expect("Invalid base64 string (DATA_APP_ID)")
-});
+pub(crate) const DATA_APP_ID: &str = comptime_b64!("dml6X2FwcF9pZA==");
 
 /// Expanded `VM` app name
-pub static EXPAND_VM_NAME: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("dml6bWFuZ2E=")
-            .expect("Failed to decode base64 EXPAND_VM_NAME"),
-    )
-    .expect("Invalid base64 string (EXPAND_VM_NAME)")
-});
+pub const EXPAND_VM_NAME: &str = comptime_b64!("dml6bWFuZ2E=");
 /// Expanded `SJ` app name
-pub static EXPAND_SJ_NAME: LazyLock<String> = LazyLock::new(|| {
-    String::from_utf8(
-        general_purpose::STANDARD
-            .decode("c2hvbmVuanVtcA==")
-            .expect("Failed to decode base64 EXPAND_SJ_NAME"),
-    )
-    .expect("Invalid base64 string (EXPAND_SJ_NAME)")
-});
+pub const EXPAND_SJ_NAME: &str = comptime_b64!("c2hvbmVuanVtcA==");
 
 /// Returns the constants for the given device type.
 ///

--- a/tosho_sjv/src/lib.rs
+++ b/tosho_sjv/src/lib.rs
@@ -79,7 +79,7 @@ impl SJClient {
         );
         headers.insert(
             reqwest::header::HOST,
-            reqwest::header::HeaderValue::from_static(&API_HOST),
+            reqwest::header::HeaderValue::from_static(API_HOST),
         );
         let referer = match mode {
             SJMode::VM => &constants.vm_name,
@@ -90,9 +90,9 @@ impl SJClient {
             reqwest::header::HeaderValue::from_static(referer),
         );
 
-        let x_header = format!("{} {}", constants.app_ver, &*VALUE_PIECE);
+        let x_header = format!("{} {}", constants.app_ver, VALUE_PIECE);
         headers.insert(
-            reqwest::header::HeaderName::from_static(&HEADER_PIECE),
+            reqwest::header::HeaderName::from_static(HEADER_PIECE),
             reqwest::header::HeaderValue::from_str(&x_header).map_err(|_| {
                 ToshoClientError::HeaderParseError(format!("Header piece of {}", &x_header))
             })?,
@@ -149,7 +149,7 @@ impl SJClient {
     where
         T: serde::de::DeserializeOwned,
     {
-        let endpoint = format!("{}{}", &*BASE_API, endpoint);
+        let endpoint = format!("{}{}", BASE_API, endpoint);
 
         let request = match (data.clone(), params.clone()) {
             (None, None) => self.inner.request(method, endpoint),
@@ -287,7 +287,7 @@ impl SJClient {
                 // web didn't return JSON response but direct URL
                 let response = self
                     .inner
-                    .post(format!("{}/manga/get_manga_url", &*BASE_API))
+                    .post(format!("{}/manga/get_manga_url", BASE_API))
                     .form(&data)
                     .send()
                     .await?;
@@ -458,7 +458,7 @@ impl SJClient {
         );
         headers.insert(
             reqwest::header::HOST,
-            reqwest::header::HeaderValue::from_static(&API_HOST),
+            reqwest::header::HeaderValue::from_static(API_HOST),
         );
         let referer = match mode {
             SJMode::VM => &constants.vm_name,
@@ -469,9 +469,9 @@ impl SJClient {
             reqwest::header::HeaderValue::from_static(referer),
         );
 
-        let x_header = format!("{} {}", constants.app_ver, &*VALUE_PIECE);
+        let x_header = format!("{} {}", constants.app_ver, VALUE_PIECE);
         headers.insert(
-            reqwest::header::HeaderName::from_static(&HEADER_PIECE),
+            reqwest::header::HeaderName::from_static(HEADER_PIECE),
             reqwest::header::HeaderValue::from_str(&x_header).map_err(|_| {
                 ToshoClientError::HeaderParseError(format!("Header piece of {}", &x_header))
             })?,
@@ -499,7 +499,7 @@ impl SJClient {
         };
 
         let response = client
-            .post(format!("{}/manga/try_manga_login", &*BASE_API))
+            .post(format!("{}/manga/try_manga_login", BASE_API))
             .form(&data)
             .header(
                 reqwest::header::CONTENT_TYPE,
@@ -539,7 +539,7 @@ fn common_data_hashmap(
     data.insert("version".to_string(), LIB_VERSION.to_string());
     data.insert(DATA_APP_ID.to_string(), app_id.to_string());
     if let Some(version_body) = &constants.version_body {
-        data.insert(version_body.clone(), constants.app_ver.to_string());
+        data.insert(version_body.to_string(), constants.app_ver.to_string());
     }
     data
 }


### PR DESCRIPTION
This should improve runtime performance since the decoding and lazylock overhead
No significant compile time decreases as far as I can see